### PR TITLE
View corrections

### DIFF
--- a/Authentication.xcodeproj/project.pbxproj
+++ b/Authentication.xcodeproj/project.pbxproj
@@ -299,9 +299,9 @@
 		9D72AA121C8DC7EB00BB4082 /* AuthenticationTests */ = {
 			isa = PBXGroup;
 			children = (
-				CE89A25A1CAEC68300E1903B /* Signup */,
 				CEE4049A1C9A061200AB70B3 /* Validators */,
 				CEFB5F7B1C91BBC600760A2A /* Login */,
+				CE89A25A1CAEC68300E1903B /* Signup */,
 				9D72AA151C8DC7EB00BB4082 /* Info.plist */,
 			);
 			path = AuthenticationTests;

--- a/Authentication.xcodeproj/project.pbxproj
+++ b/Authentication.xcodeproj/project.pbxproj
@@ -278,10 +278,10 @@
 		9D72AA061C8DC7EA00BB4082 /* Authentication */ = {
 			isa = PBXGroup;
 			children = (
-				CE89A2611CAED30100E1903B /* Configuration */,
 				CEE226A91C9C4011005EB279 /* Localizable.strings */,
 				CEE226AC1C9C4018005EB279 /* Spanish(es).strings */,
 				CEE226A41C9C3CB4005EB279 /* RecoverPassword */,
+				CE89A2611CAED30100E1903B /* Configuration */,
 				CE040D721C99CD7D0020DDE0 /* Validators */,
 				CEBF66B51C8DD3AB006EE090 /* Login */,
 				CEBF66B41C8DD3A4006EE090 /* Signup */,

--- a/Authentication/AuthenticationBootstrapper.swift
+++ b/Authentication/AuthenticationBootstrapper.swift
@@ -348,35 +348,41 @@ public extension AuthenticationBootstrapper {
 
 extension AuthenticationBootstrapper: LoginControllerTransitionDelegate {
     
+    /**
+         Function that reacts to the user pressing "Sign Up" in the
+         login screen.
+         It will push the new controller in the navigation controller.
+     */
     public func onSignup(controller: LoginController) {
         let signupController = createSignupController()
-        if let navigationController = controller.navigationController {
-            navigationController.pushViewController(signupController, animated: true)
-        } else {
-            _window.rootViewController = UINavigationController(rootViewController: signupController)
-        }
+        // The authentication framework starts the process with a navigation controller.
+        controller.navigationController!.pushViewController(signupController, animated: true)
     }
     
+    /**
+         Function that reacts to the user pressing "Recover Password"
+         in the login screen.
+         It will push the new controller in the navigation controller.
+     */
     public func onRecoverPassword(controller: LoginController) {
         let recoverPasswordController = createRecoverPasswordController()
-        if let navigationController = controller.navigationController {
-            navigationController.pushViewController(recoverPasswordController, animated: true)
-        } else {
-            _window.rootViewController = UINavigationController(rootViewController: recoverPasswordController)
-        }
+        // The authentication framework starts the process with a navigation controller.
+        controller.navigationController!.pushViewController(recoverPasswordController, animated: true)
     }
     
 }
 
 extension AuthenticationBootstrapper: SignupControllerTransitionDelegate {
     
+    /**
+         Function that reacts to the user pressing "Log In"
+         in the signup screen.
+         It will pop the signup controller from the navigation controller,
+         to return to login screen.
+     */
     public func onLogin(controller: SignupController) {
-        let loginController = createLoginController()
-        if let navigationController = controller.navigationController {
-            navigationController.popViewControllerAnimated(true)
-        } else {
-            _window.rootViewController = UINavigationController(rootViewController: loginController)
-        }
+        // The authentication framework starts the process with a navigation controller.
+        controller.navigationController!.popViewControllerAnimated(true)
     }
     
 }

--- a/Authentication/AuthenticationBootstrapper.swift
+++ b/Authentication/AuthenticationBootstrapper.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-/**
+/*
     Bootstrapper to start the application.
     Takes care of starting the authentication process before the main View Controller of the app when necessary,
     and after the user logs out.
@@ -34,7 +34,7 @@ public class AuthenticationBootstrapper<User: UserType, SessionService: SessionS
         return sessionService.currentUser.value
     }
 
-    /**
+    /*
         Initializes a new authentication bootstrapper with the session service to use for logging in and out and
         the factory method from where to obtain the main View Controller of the application.
 
@@ -64,7 +64,7 @@ public class AuthenticationBootstrapper<User: UserType, SessionService: SessionS
         }
     }
 
-    /**
+    /*
         Bootstraps your project with the authentication framework,
         starting with the authentication project if no user is already logged in the session service.
         Otherwise, it runs your project directly from starting the Main View Controller.
@@ -81,7 +81,7 @@ public class AuthenticationBootstrapper<User: UserType, SessionService: SessionS
 // MARK: - Login Functions
 public extension AuthenticationBootstrapper {
     
-    /**
+    /*
          Creates the login controller to use for starting
          the authentication process.
          
@@ -92,7 +92,7 @@ public extension AuthenticationBootstrapper {
         return LoginController(configuration: configuration)
     }
     
-    /**
+    /*
         Creates the log in credential validator that embodies what must be met
         so as to enable the log in for the user.
 
@@ -105,7 +105,7 @@ public extension AuthenticationBootstrapper {
         return LoginCredentialsValidator()
     }
 
-    /**
+    /*
          Creates the LoginViewModelType to use in the authentication process logic,
          with the LogInCredentialsValidator returned in the function createLogInCredentialsValidator.
 
@@ -120,7 +120,7 @@ public extension AuthenticationBootstrapper {
         return LoginViewModel(sessionService: sessionService, credentialsValidator: createLogInCredentialsValidator())
     }
 
-    /**
+    /*
         Creates login view that conforms to the logInViewType protocol
         and will be use for the login visual.
 
@@ -135,7 +135,7 @@ public extension AuthenticationBootstrapper {
         return view
     }
     
-    /**
+    /*
          Creates the LoginViewDelegate to use in configuring the login view style.
          
          - Returns: A login view delegate that controls the color and font palette
@@ -153,7 +153,7 @@ public extension AuthenticationBootstrapper {
         return DefaultLoginViewDelegate(configuration: _viewConfiguration.loginConfiguration)
     }
 
-    /**
+    /*
         Creates the login view controller delegate that the login controller
         will use to add behaviour to certain events, described in
         LoginControllerDelegate protocol.
@@ -167,7 +167,7 @@ public extension AuthenticationBootstrapper {
         return DefaultLoginControllerDelegate()
     }
     
-    /**
+    /*
          Creates the login view controller configuration that the login controller
          will use to access the login view model to use,
          the login view to display and the transition delegate
@@ -185,7 +185,7 @@ public extension AuthenticationBootstrapper {
             transitionDelegate: createLoginControllerTransitionDelegate())
     }
     
-    /**
+    /*
          Creates the login controller transition delegate that
          the login controller will use to handle transitions
          to other screens (like signup).
@@ -205,7 +205,7 @@ public extension AuthenticationBootstrapper {
 // MARK: - Signup Functions
 public extension AuthenticationBootstrapper {
     
-    /**
+    /*
          Creates the signup controller to use when the
          user selects that option.
          
@@ -215,7 +215,7 @@ public extension AuthenticationBootstrapper {
         return SignupController(configuration: createSignupControllerConfiguration())
     }
     
-    /**
+    /*
          Creates the SignupViewModel to use in the registration process logic,
          with the SignUpCredentialsValidator returned in the function createSignUpCredentialsValidator,
          and the configuration given to the AuthenticationBootstrapper in its AuthenticationViewConfiguration.
@@ -232,7 +232,7 @@ public extension AuthenticationBootstrapper {
                                usernameEnabled: _viewConfiguration.signupConfiguration.usernameEnabled)
     }
     
-    /**
+    /*
          Creates the sign up credential validator that embodies the criteria that must be met
          so as to enable the sign up for the user.
          
@@ -247,7 +247,7 @@ public extension AuthenticationBootstrapper {
         return SignupCredentialsValidator()
     }
     
-    /**
+    /*
          Creates signup view that conforms to the logInViewType protocol
          and will be use for the login visual.
          
@@ -261,7 +261,7 @@ public extension AuthenticationBootstrapper {
         return view
     }
     
-    /**
+    /*
          Creates the SignupViewDelegate to use in configuring the signup view style.
          
          - Returns: A signup view delegate that controls the color and font palette
@@ -279,7 +279,7 @@ public extension AuthenticationBootstrapper {
         return DefaultSignupViewDelegate(configuration: _viewConfiguration.signupConfiguration)
     }
     
-    /**
+    /*
          Creates the signup view controller delegate
          that the signup controller will use to add behaviour
          to certain events, described in SignupControllerDelegate
@@ -294,7 +294,7 @@ public extension AuthenticationBootstrapper {
         return DefaultSignupControllerDelegate()
     }
     
-    /**
+    /*
          Creates the signup view controller configuration that the signup controller
          will use to access the signup view model to use,
          the signup view to display and the transition delegate
@@ -312,7 +312,7 @@ public extension AuthenticationBootstrapper {
             transitionDelegate: createSignupControllerTransitionDelegate())
     }
     
-    /**
+    /*
          Creates the signup controller transition delegate that
          the signup controller will use to handle transitions
          to other screens (like login or terms and services).
@@ -331,7 +331,7 @@ public extension AuthenticationBootstrapper {
 
 // MARK: - RecoverPassword Functions
 public extension AuthenticationBootstrapper {
-    /**
+    /*
          Creates the recover password main controller to use when the
          user selects that option.
          
@@ -348,7 +348,7 @@ public extension AuthenticationBootstrapper {
 
 extension AuthenticationBootstrapper: LoginControllerTransitionDelegate {
     
-    /**
+    /*
          Function that reacts to the user pressing "Sign Up" in the
          login screen.
          It will push the new controller in the navigation controller.
@@ -359,7 +359,7 @@ extension AuthenticationBootstrapper: LoginControllerTransitionDelegate {
         controller.navigationController!.pushViewController(signupController, animated: true)
     }
     
-    /**
+    /*
          Function that reacts to the user pressing "Recover Password"
          in the login screen.
          It will push the new controller in the navigation controller.
@@ -374,7 +374,7 @@ extension AuthenticationBootstrapper: LoginControllerTransitionDelegate {
 
 extension AuthenticationBootstrapper: SignupControllerTransitionDelegate {
     
-    /**
+    /*
          Function that reacts to the user pressing "Log In"
          in the signup screen.
          It will pop the signup controller from the navigation controller,

--- a/Authentication/AuthenticationBootstrapper.swift
+++ b/Authentication/AuthenticationBootstrapper.swift
@@ -18,9 +18,12 @@ public class AuthenticationBootstrapper<User: UserType, SessionService: SessionS
 
     /// The window of the app
     private let _window: UIWindow
+    
     /// The factory method from which to obtain a main View Controller for the app
     private let _mainViewControllerFactory: () -> UIViewController
+    
     /// The configuration that defines colour and fonts and assets, like the logo, used in the views.
+    /// It also includes other configurations like the textfields selected to use in signup.
     private let _viewConfiguration: AuthenticationViewConfiguration
     
     /// The entry and exit point to the user's session.
@@ -43,11 +46,9 @@ public class AuthenticationBootstrapper<User: UserType, SessionService: SessionS
 
         - Returns: A new authentication bootstrapper ready to use for starting your app as needed.
     */
-// swiftlint:disable valid_docs
     public init(sessionService: SessionService, window: UIWindow,
         viewConfiguration: AuthenticationViewConfiguration = AuthenticationViewConfiguration(),
         mainViewControllerFactory: () -> UIViewController) {
-// swiftlint:enable valid_docs
         _window = window
         _mainViewControllerFactory = mainViewControllerFactory
         _viewConfiguration = viewConfiguration
@@ -66,7 +67,7 @@ public class AuthenticationBootstrapper<User: UserType, SessionService: SessionS
     /**
         Bootstraps your project with the authentication framework,
         starting with the authentication project if no user is already logged in the session service.
-        Otherwise, it runs your project directly from starting the main View Controller.
+        Otherwise, it runs your project directly from starting the Main View Controller.
     */
     public final func bootstrap() {
         if let _ = self.currentUser {
@@ -75,7 +76,22 @@ public class AuthenticationBootstrapper<User: UserType, SessionService: SessionS
             _window.rootViewController = UINavigationController(rootViewController: createLoginController())
         }
     }
+}
 
+// MARK: - Login Functions
+public extension AuthenticationBootstrapper {
+    
+    /**
+         Creates the login controller to use for starting
+         the authentication process.
+         
+         - Returns: A valid login controller to use.
+     */
+    internal func createLoginController() -> LoginController {
+        let configuration = createLoginControllerConfiguration()
+        return LoginController(configuration: configuration)
+    }
+    
     /**
         Creates the log in credential validator that embodies what must be met
         so as to enable the log in for the user.
@@ -83,21 +99,24 @@ public class AuthenticationBootstrapper<User: UserType, SessionService: SessionS
         - Returns: A log in credentials validator to use for creating the LogInViewModel.
 
         - Attention: Override this method for customizing the criteria of email and password validity.
+        You can use email as username if you use the correct validator for it.
     */
     public func createLogInCredentialsValidator() -> LoginCredentialsValidator {
         return LoginCredentialsValidator()
     }
 
     /**
-         Creates the LogInViewModel to use in the authentication process logic,
+         Creates the LoginViewModelType to use in the authentication process logic,
          with the LogInCredentialsValidator returned in the function createLogInCredentialsValidator.
 
          - Returns: A login view model that controls the login logic and communicates with the session service.
 
-         - Warning: The LogInViewModel returned must be constructed with the same session service as the
-         authentication bootstrapper.
+         - Attention: Override this method for using your own login logic, your own login view model.
+     
+         - Warning: The LoginViewModel returned must be constructed with the same session service as the
+         authentication bootstrapper, if it needs a session service, like the default one.
      */
-    public func createLoginViewModel() -> LoginViewModel<User, SessionService> {
+    public func createLoginViewModel() -> LoginViewModelType {
         return LoginViewModel(sessionService: sessionService, credentialsValidator: createLogInCredentialsValidator())
     }
 
@@ -107,17 +126,37 @@ public class AuthenticationBootstrapper<User: UserType, SessionService: SessionS
 
         - Returns: A valid login view ready to be used.
      
-        - Attention: Override this method for customizing the view for the login.
+        - Attention: Override this method for customizing the view for the login,
+        other than the provided by LoginViewDelegate and LoginViewConfigurationType.
     */
     public func createLoginView() -> LoginViewType {
         let view: LoginView = .loadFromNib()
-        view.delegate = DefaultLoginViewDelegate(configuration: _viewConfiguration.loginConfiguration)
+        view.delegate = createLoginViewDelegate()
         return view
+    }
+    
+    /**
+         Creates the LoginViewDelegate to use in configuring the login view style.
+         
+         - Returns: A login view delegate that controls the color and font palette
+         setting of the view.
+         
+         - Attention: Override this method for using you own LoginViewDelegate,
+         when configuring the default one with the AuthenticationViewConfiguration
+         passed to the AuthenticationBootstrapper is not enough, or the binding
+         logic of view elements and palette hierarchy must be changed.
+     
+         - Warning: The LoginViewDelegate returned must consider the LoginViewConfigurationType
+         the AuthenticationBootstrapper holds in its view configuration.
+     */
+    public func createLoginViewDelegate() -> LoginViewDelegate {
+        return DefaultLoginViewDelegate(configuration: _viewConfiguration.loginConfiguration)
     }
 
     /**
         Creates the login view controller delegate that the login controller
-        will use to add behaviour to certain events.
+        will use to add behaviour to certain events, described in
+        LoginControllerDelegate protocol.
      
         - Returns: A valid login controller delegate to use.
      
@@ -128,48 +167,58 @@ public class AuthenticationBootstrapper<User: UserType, SessionService: SessionS
         return DefaultLoginControllerDelegate()
     }
     
+    /**
+         Creates the login view controller configuration that the login controller
+         will use to access the login view model to use,
+         the login view to display and the transition delegate
+         to use for transitions to other screens.
+         
+         - Returns: A valid login controller configuration to use.
+         
+         - Attention: Override this method for customizing any of the used
+         configuration's parameters.
+     */
     public func createLoginControllerConfiguration() -> LoginControllerConfiguration {
         return LoginControllerConfiguration(
             viewModel: createLoginViewModel(),
             viewFactory: createLoginView,
-            transitionDelegate: self)
+            transitionDelegate: createLoginControllerTransitionDelegate())
     }
     
-    public func createLoginController() -> LoginController {
-        let configuration = createLoginControllerConfiguration()
-        return LoginController(configuration: configuration)
+    /**
+         Creates the login controller transition delegate that
+         the login controller will use to handle transitions
+         to other screens (like signup).
+         
+         - Returns: A valid login controller transition delegate to use.
+         
+         - Attention: Override this method for customizing any of the transitions
+         in a way where overriding the transition's delegate methods of the
+         AuthenticationBootstrapper isn't enough.
+     */
+    public func createLoginControllerTransitionDelegate() -> LoginControllerTransitionDelegate {
+        return self
     }
-    
+
+}
+
+// MARK: - Signup Functions
+public extension AuthenticationBootstrapper {
     
     /**
          Creates the signup controller to use when the
          user selects that option.
          
          - Returns: A valid signup controller to use.
-         
-         - Attention: Override this method for customizing the
-         signup controller to be used.
     */
-    public func createSignupController() -> SignupController {
+    internal func createSignupController() -> SignupController {
         return SignupController(configuration: createSignupControllerConfiguration())
-    }
-    
-    public func createSignupControllerConfiguration() -> SignupControllerConfiguration {
-        return SignupControllerConfiguration(
-            viewModel: createSignupViewModel(),
-            viewFactory: createSignupView,
-            transitionDelegate: self)
-    }
-    
-    public func createSignupView() -> SignupViewType {
-        let view = SignupView.loadFromNib()
-        view.delegate = DefaultSignupViewDelegate(configuration: _viewConfiguration.signupConfiguration)
-        return view
     }
     
     /**
          Creates the SignupViewModel to use in the registration process logic,
-         with the SignUpCredentialsValidator returned in the function createSignUpCredentialsValidator.
+         with the SignUpCredentialsValidator returned in the function createSignUpCredentialsValidator,
+         and the configuration given to the AuthenticationBootstrapper in its AuthenticationViewConfiguration.
          
          - Returns: A signup view model that controls the registration logic and comunicates with the session service.
          
@@ -183,14 +232,58 @@ public class AuthenticationBootstrapper<User: UserType, SessionService: SessionS
                                usernameEnabled: _viewConfiguration.signupConfiguration.usernameEnabled)
     }
     
+    /**
+         Creates the sign up credential validator that embodies the criteria that must be met
+         so as to enable the sign up for the user.
+         
+         - Returns: A sign up credentials validator to use for creating the SignupViewModel.
+         
+         - Attention: Override this method for customizing the criteria of username, email
+         and password validity.
+         You can set in SignupConfiguration which textfields to use during signup so if you
+         won't use one of them, you don't have to worry about its validator.
+     */
     public func createSignUpCredentialsValidator() -> SignupCredentialsValidator {
-        return SignupCredentialsValidator(nameValidator: AlwaysValidValidator())
+        return SignupCredentialsValidator()
+    }
+    
+    /**
+         Creates signup view that conforms to the logInViewType protocol
+         and will be use for the login visual.
+         
+         - Returns: A valid login view ready to be used.
+         
+         - Attention: Override this method for customizing the view for the login.
+     */
+    public func createSignupView() -> SignupViewType {
+        let view = SignupView.loadFromNib()
+        view.delegate = DefaultSignupViewDelegate(configuration: _viewConfiguration.signupConfiguration)
+        return view
+    }
+    
+    /**
+         Creates the SignupViewDelegate to use in configuring the signup view style.
+         
+         - Returns: A signup view delegate that controls the color and font palette
+        setting of the view.
+     
+         - Attention: Override this method for using you own SignupViewDelegate,
+         when configuring the default one with the AuthenticationViewConfiguration
+         passed to the AuthenticationBootstrapper is not enough, or the binding
+         logic of view elements and palette hierarchy must be changed.
+         
+         - Warning: The SignupViewDelegate returned must consider the SignupViewConfigurationType
+         the AuthenticationBootstrapper holds in its view configuration.
+     */
+    public func createSignupViewDelegate() -> SignupViewDelegate {
+        return DefaultSignupViewDelegate(configuration: _viewConfiguration.signupConfiguration)
     }
     
     /**
          Creates the signup view controller delegate
          that the signup controller will use to add behaviour
-         to certain events.
+         to certain events, described in SignupControllerDelegate
+         protocol.
          
          - Returns: A valid signup controller delegate to use.
          
@@ -202,19 +295,56 @@ public class AuthenticationBootstrapper<User: UserType, SessionService: SessionS
     }
     
     /**
+         Creates the signup view controller configuration that the signup controller
+         will use to access the signup view model to use,
+         the signup view to display and the transition delegate
+         to use for transitions to other screens.
+         
+         - Returns: A valid signup controller configuration to use.
+         
+         - Attention: Override this method for customizing any of the used
+         configuration's parameters.
+     */
+    public func createSignupControllerConfiguration() -> SignupControllerConfiguration {
+        return SignupControllerConfiguration(
+            viewModel: createSignupViewModel(),
+            viewFactory: createSignupView,
+            transitionDelegate: createSignupControllerTransitionDelegate())
+    }
+    
+    /**
+         Creates the signup controller transition delegate that
+         the signup controller will use to handle transitions
+         to other screens (like login or terms and services).
+         
+         - Returns: A valid login controller transition delegate to use.
+         
+         - Attention: Override this method for customizing any of the transitions
+         in a way where overriding the transition's delegate methods of the
+         AuthenticationBootstrapper isn't enough.
+     */
+    public func createSignupControllerTransitionDelegate() -> SignupControllerTransitionDelegate {
+        return self
+    }
+    
+}
+
+// MARK: - RecoverPassword Functions
+public extension AuthenticationBootstrapper {
+    /**
          Creates the recover password main controller to use when the
          user selects that option.
          
          - Returns: A valid recover password controller to use.
-         
-         - Attention: Override this method for customizing the
-         recover password main controller to be used.
      */
-    public func createRecoverPasswordController() -> RecoverPasswordController { //todo
+    public func createRecoverPasswordController() -> RecoverPasswordController {
+        // TODO
         return RecoverPasswordController()
     }
     
 }
+
+
 
 extension AuthenticationBootstrapper: LoginControllerTransitionDelegate {
     

--- a/Authentication/Configuration/AuthenticationViewConfiguration.swift
+++ b/Authentication/Configuration/AuthenticationViewConfiguration.swift
@@ -6,14 +6,20 @@
 //  Copyright © 2016 Wolox. All rights reserved.
 //
 
-import Foundation
 
+/*
+     Represents the view configurations able to
+     be customized in all authentication process.
+ 
+     Includes the login and signup view configurations.
+ */
 public struct AuthenticationViewConfiguration {
     
     public let loginConfiguration: LoginViewConfigurationType
     public let signupConfiguration: SignupViewConfigurationType
     
-    public init(loginViewConfiguration: LoginViewConfigurationType = DefaultLoginViewConfiguration(), signupViewConfiguration: SignupViewConfigurationType = DefaultSignupViewConfiguration()) {
+    public init(loginViewConfiguration: LoginViewConfigurationType = LoginViewConfiguration(),
+                signupViewConfiguration: SignupViewConfigurationType = SignupViewConfiguration()) {
         loginConfiguration = loginViewConfiguration
         signupConfiguration = signupViewConfiguration
     }

--- a/Authentication/Configuration/ColorPalette.swift
+++ b/Authentication/Configuration/ColorPalette.swift
@@ -6,9 +6,14 @@
 //  Copyright © 2016 Wolox. All rights reserved.
 //
 
-import Foundation
 
+/*
+     Represents the color hierarchy necessary for
+     an authentication view.
+ */
 public protocol ColorPaletteType {
+    
+    var background: UIColor { get }
     
     var mainButtonDisabled: UIColor { get }
     var mainButtonEnabled: UIColor { get }
@@ -18,8 +23,8 @@ public protocol ColorPaletteType {
     var textfieldsNormal: UIColor { get }
     var textfieldsSelected: UIColor { get }
     
-    var background: UIColor { get }
-    
+    // Links refers to any navigational button or
+    // link present in the view.
     var links: UIColor { get }
     var labels: UIColor { get }
     var textfieldText: UIColor { get }

--- a/Authentication/Configuration/FontPalette.swift
+++ b/Authentication/Configuration/FontPalette.swift
@@ -6,22 +6,27 @@
 //  Copyright © 2016 Wolox. All rights reserved.
 //
 
-import Foundation
-
 /*
- All fonts used should be from the same family
- for style coherence.
+     Represents the font hierarchy necessary for
+     an authentication view.
+ 
+     All fonts used should be from the same family
+     for style coherence.
  */
 public protocol FontPaletteType {
     
     var textfields: UIFont { get }
     var passwordVisibilityButton: UIFont { get }
+    // Links refers to any navigational button or
+    // link present in the view.
     var links: UIFont { get }
     var labels: UIFont { get }
     var mainButton: UIFont { get }
     
 }
 
+/* By default, the FontPalette uses the SystemFont family, and
+ only highlights the main button text with bigger and bold font. */
 public extension FontPaletteType {
     
     public var textfields: UIFont { return .systemFontOfSize(14) }

--- a/Authentication/Configuration/FontPalette.swift
+++ b/Authentication/Configuration/FontPalette.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-/**
+/*
  All fonts used should be from the same family
  for style coherence.
  */

--- a/Authentication/Extensions.swift
+++ b/Authentication/Extensions.swift
@@ -19,3 +19,17 @@ public extension String {
     }
     
 }
+
+public extension UIButton {
+    
+    public func setUnderlinedTitle(title: String, style: NSUnderlineStyle = .StyleSingle, color: UIColor? = .None, forState state: UIControlState = .Normal) {
+        var attributes: [String : AnyObject] = [NSUnderlineStyleAttributeName: style.rawValue]
+        if let colorAttr = color {
+            attributes[NSUnderlineColorAttributeName] = colorAttr
+        }
+        let underlinedText = NSAttributedString(string: title, attributes: attributes)
+        setAttributedTitle(underlinedText, forState: state)
+
+    }
+    
+}

--- a/Authentication/Login/Model/Email.swift
+++ b/Authentication/Login/Model/Email.swift
@@ -8,7 +8,9 @@
 
 import Foundation
 
-
+/*
+     Represents a valid email.
+ */
 public struct Email {
     
     public static func isValidEmail(raw: String) -> Bool {

--- a/Authentication/Login/Model/User.swift
+++ b/Authentication/Login/Model/User.swift
@@ -9,8 +9,9 @@
 import Foundation
 
 /*
-     Represents a user compatible
-     with the authentication framework.
+     Represents all properties needed from
+     a user for it to be compatible with
+     the authentication framework.
  */
 public protocol UserType {
     

--- a/Authentication/Login/Model/User.swift
+++ b/Authentication/Login/Model/User.swift
@@ -8,7 +8,10 @@
 
 import Foundation
 
-
+/*
+     Represents a user compatible
+     with the authentication framework.
+ */
 public protocol UserType {
     
 }

--- a/Authentication/Login/View/LoginConfiguration.swift
+++ b/Authentication/Login/View/LoginConfiguration.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-/**
+/*
     Protocol for handling transition events occured during login.
 */
 public protocol LoginControllerTransitionDelegate {
@@ -20,7 +20,7 @@ public protocol LoginControllerTransitionDelegate {
 }
 
 
-/**
+/*
     Class for configuring the login controller.
     Includes all information required:
         view factory method,
@@ -35,7 +35,7 @@ public final class LoginControllerConfiguration {
     public let delegate: LoginControllerDelegate
     public let transitionDelegate: LoginControllerTransitionDelegate
     
-    /**
+    /*
         Initializes a login controller configuration with the view model,
         delegate, a factory method for the login view and transition 
         delegate for the login controller to use.

--- a/Authentication/Login/View/LoginConfiguration.swift
+++ b/Authentication/Login/View/LoginConfiguration.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2016 Wolox. All rights reserved.
 //
 
-import Foundation
-
 /*
     Protocol for handling transition events occured during login.
 */

--- a/Authentication/Login/View/LoginConfiguration.swift
+++ b/Authentication/Login/View/LoginConfiguration.swift
@@ -52,9 +52,7 @@ public final class LoginControllerConfiguration {
      
         - Returns: A valid configuration
     */
-// swiftlint:disable valid_docs
     init(viewModel: LoginViewModelType,
-// swiftlint:enable valid_docs
         viewFactory: () -> LoginViewType,
         transitionDelegate: LoginControllerTransitionDelegate,
         delegate: LoginControllerDelegate = DefaultLoginControllerDelegate()) {

--- a/Authentication/Login/View/LoginConfiguration.swift
+++ b/Authentication/Login/View/LoginConfiguration.swift
@@ -46,11 +46,11 @@ public final class LoginControllerConfiguration {
              to get the login view to use.
              - transitionDelegate: delegate to handle events that fire a
              transition, like selecting registration or recover password.
-             - delegate: delegate which adds behaviour to certain
-             events, like handling a login error or selecting log in option.
+             - delegate: delegate which adds behaviour to certain events,
+             like handling a login error or selecting log in option.
              A default delegate is provided.
      
-        - Returns: A valid configuration
+        - Returns: A valid configuration.
     */
     init(viewModel: LoginViewModelType,
         viewFactory: () -> LoginViewType,

--- a/Authentication/Login/View/LoginController.swift
+++ b/Authentication/Login/View/LoginController.swift
@@ -20,9 +20,9 @@ import enum Result.NoError
     If there are more than one validation error in a field, the controller
     presents only the first one in the errors label.
  
-    If wanting to use the default LoginController, you should not override
-    the `createLoginController` method of the Bootstrapper, but all the others
-    that provide the elements this controller uses. (That is to say,
+    If wanting to use the default LoginController with some customization,
+    you should not override the `createLoginController` method of the Bootstrapper,
+    but all the others that provide the elements this controller uses. (That is to say,
     `createLoginView`, `createLoginViewModel`, `createLoginControllerDelegate`
     and/or `createLoginControllerConfiguration`)
  */

--- a/Authentication/Login/View/LoginController.swift
+++ b/Authentication/Login/View/LoginController.swift
@@ -12,7 +12,7 @@ import Rex
 import enum Result.NoError
 
 
-/**
+/*
     Log In View Controller that takes care of managing the login, from
     validating email and password fields, to binding a login view to the
     view model and informing the log in controller delegate when certain
@@ -34,12 +34,12 @@ public final class LoginController: UIViewController {
     private let _keyboardDisplayed = MutableProperty(false)
     private let _activeField = MutableProperty<UITextField?>(.None)
     
-    // This is an internal initializer, because if wanting to use the  default SignupController,
+    // This is an internal initializer, because if wanting to use the default SignupController,
     // you should not override the `createLoginController` method, but all the others
     // that provide the elements this controller uses. (That is to say,
     // `createLoginView`, `createLoginViewModel`, `createLoginControllerDelegate` or
     // `createLoginControllerConfiguration`)
-    /**
+    /*
         Initializes a login controller with the configuration to use.
      
         Parameters:
@@ -130,7 +130,7 @@ private extension LoginController {
         }
         if let passwordVisibilityButton = loginView.passwordVisibilityButton {
             passwordVisibilityButton.rex_pressed.value = _viewModel.togglePasswordVisibility
-            _viewModel.showPassword.signal.observeNext { [unowned self] in self.loginView.passwordVisible = $0 }
+            _viewModel.passwordVisible.signal.observeNext { [unowned self] in self.loginView.passwordVisible = $0 }
         }
         loginView.passwordTextField.delegate = self
     }
@@ -229,7 +229,7 @@ private extension LoginController {
         return navBarHeight + statusBarHeight
     }
     
-    /**
+    /*
         As both textfields fit in all devices, it will always show the email
         textfield at the top of the screen.
     */

--- a/Authentication/Login/View/LoginController.swift
+++ b/Authentication/Login/View/LoginController.swift
@@ -108,6 +108,7 @@ private extension LoginController {
             } else {
                 self._delegate.didFailEmailValidation(self, with: errors)
             }
+            self.loginView.emailTextFieldValid = errors.isEmpty
         }
         if let emailValidationMessageLabel = loginView.emailValidationMessageLabel {
             emailValidationMessageLabel.rex_text <~ _viewModel.emailValidationErrors.signal.map { $0.first ?? " " }
@@ -125,6 +126,7 @@ private extension LoginController {
             } else {
                 self._delegate.didFailPasswordValidation(self, with: errors)
             }
+            self.loginView.passwordTextFieldValid = errors.isEmpty
         }
         if let passwordValidationMessageLabel = loginView.passwordValidationMessageLabel {
             passwordValidationMessageLabel.rex_text <~ _viewModel.passwordValidationErrors.signal.map { $0.first ?? " " }

--- a/Authentication/Login/View/LoginController.swift
+++ b/Authentication/Login/View/LoginController.swift
@@ -13,12 +13,18 @@ import enum Result.NoError
 
 
 /*
-    Log In View Controller that takes care of managing the login, from
+    Login View Controller that takes care of managing the login, from
     validating email and password fields, to binding a login view to the
-    view model and informing the log in controller delegate when certain
+    view model and informing the login controller delegate when certain
     events occur for it to act upon them.
-    If there are more than one errors in a field, the controller presents
-    only the first one in the errors label.
+    If there are more than one validation error in a field, the controller
+    presents only the first one in the errors label.
+ 
+    If wanting to use the default LoginController, you should not override
+    the `createLoginController` method of the Bootstrapper, but all the others
+    that provide the elements this controller uses. (That is to say,
+    `createLoginView`, `createLoginViewModel`, `createLoginControllerDelegate`
+    and/or `createLoginControllerConfiguration`)
  */
 public final class LoginController: UIViewController {
     
@@ -34,11 +40,6 @@ public final class LoginController: UIViewController {
     private let _keyboardDisplayed = MutableProperty(false)
     private let _activeField = MutableProperty<UITextField?>(.None)
     
-    // This is an internal initializer, because if wanting to use the default SignupController,
-    // you should not override the `createLoginController` method, but all the others
-    // that provide the elements this controller uses. (That is to say,
-    // `createLoginView`, `createLoginViewModel`, `createLoginControllerDelegate` or
-    // `createLoginControllerConfiguration`)
     /*
         Initializes a login controller with the configuration to use.
      

--- a/Authentication/Login/View/LoginControllerDelegate.swift
+++ b/Authentication/Login/View/LoginControllerDelegate.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 
-/**
+/*
     Protocol gor login controller delegates.
     Create your own delegate and override any of the defaut methods to
     add behaviour to your login process.

--- a/Authentication/Login/View/LoginControllerDelegate.swift
+++ b/Authentication/Login/View/LoginControllerDelegate.swift
@@ -101,4 +101,8 @@ extension LoginControllerDelegate {
     
 }
 
+/*
+    The default login controller delegate operates with the
+    default behaviour of the LoginControllerDelegate protocol's methods.
+*/
 public final class DefaultLoginControllerDelegate: LoginControllerDelegate { }

--- a/Authentication/Login/View/LoginControllerDelegate.swift
+++ b/Authentication/Login/View/LoginControllerDelegate.swift
@@ -6,41 +6,58 @@
 //  Copyright © 2016 Wolox. All rights reserved.
 //
 
-import Foundation
-
 
 /*
-    Protocol gor login controller delegates.
-    Create your own delegate and override any of the defaut methods to
-    add behaviour to your login process.
+    Protocol for login controller delegates.
+    Create your own delegate and override any of
+    the defaut methods to add behaviour to your
+    login process.
 */
 public protocol LoginControllerDelegate {
     
+    /* Property indicating if the login errors
+    should be shown with an alert, apart from 
+    the login errors label if it exists. */
     var shouldDisplayLoginErrorWithAlert: Bool { get }
 
+    /* Function called when the login action begins executing,
+       before setting the `logInButtonPressed` property of the view used. */
     func willExecuteLogIn(controller: LoginController)
     
+    /* Function called when the login action ended with success,
+     before setting the `logInButtonPressed` property of the view used. */
     func didExecuteLogIn(controller: LoginController)
     
+    /* Function called when the login action ended with error,
+     before setting the `logInButtonPressed` property of the view used. */
     func didLogIn(controller: LoginController, with error: SessionServiceError)
     
+    /* Function called when any new email introduced is valid,
+       before setting the `emailTextFieldValid` property of the view used. */
     func didPassEmailValidation(controller: LoginController)
     
+    /* Function called when any new email introduced is invalid,
+     before setting the `emailTextFieldValid` property of the view used. */
     func didFailEmailValidation(controller: LoginController, with errors: [String])
     
+    /* Function called when any new password introduced is valid,
+     before setting the `passwordTextFieldValid` property of the view used. */
     func didPassPasswordValidation(controller: LoginController)
     
+    /* Function called when any new password introduced is valid,
+     before setting the `passwordTextFieldValid` property of the view used. */
     func didFailPasswordValidation(controller: LoginController, with errors: [String])
     
 }
 
 extension LoginControllerDelegate {
     
+    /* By default, true. */
     public var shouldDisplayLoginErrorWithAlert: Bool { return true }
     
+    /* By default, it clears old errors from label and
+       activates the Network Activity Indicator in the status bar. */
     public func willExecuteLogIn(controller: LoginController) {
-        controller.loginView.emailTextFieldValid = true
-        controller.loginView.passwordTextFieldValid = true
         if let errorLabel = controller.loginView.logInErrorLabel {
             errorLabel.text = " "
         }
@@ -48,12 +65,18 @@ extension LoginControllerDelegate {
         app.networkActivityIndicatorVisible = true
     }
     
+    /* By default, it deactivates the Network Activity Indicator in the status bar. */
     public func didExecuteLogIn(controller: LoginController) {
         let app = UIApplication.sharedApplication()
         app.networkActivityIndicatorVisible = false
     }
     
+    /* By default, it deactivates the Network Activity Indicator in the status bar,
+       fills the error label with the error message and if the property
+       `shouldDisplayLoginErrorWithAlert` is set to true, shows an alert with the error. */
     public func didLogIn(controller: LoginController, with error: SessionServiceError) {
+        let app = UIApplication.sharedApplication()
+        app.networkActivityIndicatorVisible = false
         if let errorLabel = controller.loginView.logInErrorLabel {
             errorLabel.text = error.message
         }
@@ -64,21 +87,17 @@ extension LoginControllerDelegate {
         }
     }
     
-    public func didPassEmailValidation(controller: LoginController) {
-        controller.loginView.emailTextFieldValid = true
-    }
+    /* By default, it does nothing. */
+    public func didPassEmailValidation(controller: LoginController) { }
     
-    public func didFailEmailValidation(controller: LoginController, with errors: [String]) {
-        controller.loginView.emailTextFieldValid = false
-    }
+    /* By default, it does nothing. */
+    public func didFailEmailValidation(controller: LoginController, with errors: [String]) { }
     
-    public func didPassPasswordValidation(controller: LoginController) {
-        controller.loginView.passwordTextFieldValid = true
-    }
+    /* By default, it does nothing. */
+    public func didPassPasswordValidation(controller: LoginController) { }
     
-    public func didFailPasswordValidation(controller: LoginController, with errors: [String]) {
-        controller.loginView.passwordTextFieldValid = false
-    }
+    /* By default, it does nothing. */
+    public func didFailPasswordValidation(controller: LoginController, with errors: [String]) { }
     
 }
 

--- a/Authentication/Login/View/LoginView.swift
+++ b/Authentication/Login/View/LoginView.swift
@@ -24,6 +24,14 @@ public protocol LoginViewType: Renderable, LoginFormType {
     
 }
 
+public extension LoginViewType {
+    
+    var signupLabel: UILabel? { return .None }
+    
+    var recoverPasswordLabel: UILabel? { return .None }
+    
+}
+
 /* Default login view. */
 internal final class LoginView: UIView, LoginViewType, NibLoadable {
     
@@ -31,8 +39,6 @@ internal final class LoginView: UIView, LoginViewType, NibLoadable {
     
     internal var logoImageView: UIImageView { return logoImageViewOutlet }
     @IBOutlet weak var logoImageViewOutlet: UIImageView!
-    
-    internal var emailLabel: UILabel?
     
     internal var emailTextField: UITextField { return emailTextFieldOutlet }
     @IBOutlet weak var emailTextFieldOutlet: UITextField! {
@@ -44,8 +50,6 @@ internal final class LoginView: UIView, LoginViewType, NibLoadable {
     @IBOutlet weak var emailValidationMessageLabelOutlet: UILabel! {
         didSet { emailValidationMessageLabelOutlet.text = " " }
     }
-    
-    internal var passwordLabel: UILabel?
     
     internal var passwordTextField: UITextField { return passwordTextFieldOutlet }
     @IBOutlet weak var passwordTextFieldOutlet: UITextField! {
@@ -70,20 +74,14 @@ internal final class LoginView: UIView, LoginViewType, NibLoadable {
         }
     }
     
-    internal var logInErrorLabel: UILabel? { return .None }
-    
     @IBOutlet weak var toSignupLabel: UILabel! {
         didSet { toSignupLabel.text = signupLabelText }
     }
-    
-    internal var signupLabel: UILabel? { return .None }
     
     internal var signupButton: UIButton { return signupButtonOutlet }
     @IBOutlet weak var signupButtonOutlet: UIButton! {
         didSet { signupButton.setTitle(signupButtonTitle, forState: .Normal) }
     }
-
-    internal var recoverPasswordLabel: UILabel? { return .None }
     
     internal var recoverPasswordButton: UIButton { return recoverPasswordButtonOutlet }
     @IBOutlet weak var recoverPasswordButtonOutlet: UIButton! {

--- a/Authentication/Login/View/LoginView.swift
+++ b/Authentication/Login/View/LoginView.swift
@@ -6,16 +6,25 @@
 //  Copyright © 2016 Wolox. All rights reserved.
 //
 
+/*
+     Represents the minimum required
+     properties from a login view
+     for it to be compatible with
+     the framework.
+ */
 public protocol LoginViewType: Renderable, LoginFormType {
     
     var logoImageView: UIImageView { get }
     
-    var signupLabel: UILabel { get }
+    /* Navigation elements to other screens */
+    var signupLabel: UILabel? { get }
     var signupButton: UIButton { get }
+    var recoverPasswordLabel: UILabel? { get }
     var recoverPasswordButton: UIButton { get }
     
 }
 
+/* Default login view. */
 internal final class LoginView: UIView, LoginViewType, NibLoadable {
     
     internal lazy var delegate: LoginViewDelegate = DefaultLoginViewDelegate()
@@ -63,16 +72,19 @@ internal final class LoginView: UIView, LoginViewType, NibLoadable {
     
     internal var logInErrorLabel: UILabel? { return .None }
     
-    internal var signupLabel: UILabel { return toSignupLabel }
     @IBOutlet weak var toSignupLabel: UILabel! {
         didSet { toSignupLabel.text = signupLabelText }
     }
+    
+    internal var signupLabel: UILabel? { return .None }
     
     internal var signupButton: UIButton { return signupButtonOutlet }
     @IBOutlet weak var signupButtonOutlet: UIButton! {
         didSet { signupButton.setTitle(signupButtonTitle, forState: .Normal) }
     }
 
+    internal var recoverPasswordLabel: UILabel? { return .None }
+    
     internal var recoverPasswordButton: UIButton { return recoverPasswordButtonOutlet }
     @IBOutlet weak var recoverPasswordButtonOutlet: UIButton! {
         didSet { recoverPasswordButton.setTitle(recoverPasswordButtonTitle, forState: .Normal) }

--- a/Authentication/Login/View/LoginView.swift
+++ b/Authentication/Login/View/LoginView.swift
@@ -80,12 +80,12 @@ internal final class LoginView: UIView, LoginViewType, NibLoadable {
     
     internal var signupButton: UIButton { return signupButtonOutlet }
     @IBOutlet weak var signupButtonOutlet: UIButton! {
-        didSet { signupButton.setTitle(signupButtonTitle, forState: .Normal) }
+        didSet { signupButton.setUnderlinedTitle(signupButtonTitle) }
     }
     
     internal var recoverPasswordButton: UIButton { return recoverPasswordButtonOutlet }
     @IBOutlet weak var recoverPasswordButtonOutlet: UIButton! {
-        didSet { recoverPasswordButton.setTitle(recoverPasswordButtonTitle, forState: .Normal) }
+        didSet { recoverPasswordButton.setUnderlinedTitle(recoverPasswordButtonTitle) }
     }
     
     @IBOutlet weak var emailTextFieldViewOutlet: UIView! {

--- a/Authentication/Login/View/LoginView.xib
+++ b/Authentication/Login/View/LoginView.xib
@@ -164,8 +164,8 @@
                                     </constraints>
                                     <variation key="default">
                                         <mask key="constraints">
-                                            <exclude reference="ddn-xX-4dq"/>
                                             <exclude reference="Mqe-LV-aYE"/>
+                                            <exclude reference="ddn-xX-4dq"/>
                                         </mask>
                                     </variation>
                                 </view>

--- a/Authentication/Login/View/LoginViewConfiguration.swift
+++ b/Authentication/Login/View/LoginViewConfiguration.swift
@@ -6,8 +6,12 @@
 //  Copyright © 2016 Wolox. All rights reserved.
 //
 
-import Foundation
-
+/*
+    Represents the configurations able to
+    be customized to a LoginViewType.
+    Includes the font and color palettes,
+    and the logo image.
+*/
 public protocol LoginViewConfigurationType {
     
     var logoImage: UIImage? { get }
@@ -16,16 +20,24 @@ public protocol LoginViewConfigurationType {
     
 }
 
-public struct DefaultLoginViewConfiguration: LoginViewConfigurationType {
+/*
+     The SignupViewConfiguration stores all palettes
+     and logo necessary.
+     By default, it uses the default palettes and
+     doesn't include a logo.
+ */
+public struct LoginViewConfiguration: LoginViewConfigurationType {
     
     public let logoImage: UIImage?
     public let colorPalette: ColorPaletteType
     public let fontPalette: FontPaletteType
     
-    public init(logoImage: UIImage? = .None) {
+    public init(logoImage: UIImage? = .None,
+                colorPalette: ColorPaletteType = DefaultColorPalette(),
+                fontPalette: FontPaletteType = DefaultFontPalette()) {
         self.logoImage = logoImage
-        self.colorPalette = DefaultColorPalette()
-        self.fontPalette = DefaultFontPalette()
+        self.colorPalette = colorPalette
+        self.fontPalette = fontPalette
     }
     
 }

--- a/Authentication/Login/View/LoginViewDelegate.swift
+++ b/Authentication/Login/View/LoginViewDelegate.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-/**
+/*
     Delegate for any extra configuration
     to the login view when rendered.
 */

--- a/Authentication/Login/View/LoginViewDelegate.swift
+++ b/Authentication/Login/View/LoginViewDelegate.swift
@@ -6,29 +6,39 @@
 //  Copyright © 2016 Wolox. All rights reserved.
 //
 
-import Foundation
-
 /*
     Delegate for any extra configuration
     to the login view when rendered.
 */
 public protocol LoginViewDelegate {
     
+    /* Palettes ued to configure all login view elements possible. */
     var colorPalette: ColorPaletteType { get }
     var fontPalette: FontPaletteType { get }
     
+    /* Function to configure all view elements according to the palettes.
+       It is called by the default login view when rendered. */
     func configureView(loginView: LoginViewType)
     
 }
 
 public extension LoginViewDelegate {
     
-    func configureView(loginView: LoginViewType) {
-        
-    }
+    /* By default, does nothing. */
+    func configureView(loginView: LoginViewType) { }
     
 }
 
+/*
+    The default login view delegate takes care of:
+       setting the logo image according to the configuration and
+       setting all LoginViewType elements possible according to palettes.
+ 
+    If wanting to use the DefaultLoginViewDelegate with some palette or logo customization,
+    you should not override the `createLoginViewDelegate` method of the Bootstrapper,
+    but pass the correct LoginViewConfigurationType to the bootstraper in the
+    `AuthenticationViewConfiguration`.
+*/
 public final class DefaultLoginViewDelegate: LoginViewDelegate {
     
     private let _configuration: LoginViewConfigurationType
@@ -36,7 +46,7 @@ public final class DefaultLoginViewDelegate: LoginViewDelegate {
     public var colorPalette: ColorPaletteType { return _configuration.colorPalette }
     public var fontPalette: FontPaletteType { return _configuration.fontPalette }
     
-    init(configuration: LoginViewConfigurationType = DefaultLoginViewConfiguration()) {
+    internal init(configuration: LoginViewConfigurationType = DefaultLoginViewConfiguration()) {
         _configuration = configuration
     }
     

--- a/Authentication/Login/View/LoginViewDelegate.swift
+++ b/Authentication/Login/View/LoginViewDelegate.swift
@@ -46,7 +46,7 @@ public final class DefaultLoginViewDelegate: LoginViewDelegate {
     public var colorPalette: ColorPaletteType { return _configuration.colorPalette }
     public var fontPalette: FontPaletteType { return _configuration.fontPalette }
     
-    internal init(configuration: LoginViewConfigurationType = DefaultLoginViewConfiguration()) {
+    internal init(configuration: LoginViewConfigurationType = LoginViewConfiguration()) {
         _configuration = configuration
     }
     

--- a/Authentication/Login/View/LoginViewDelegate.swift
+++ b/Authentication/Login/View/LoginViewDelegate.swift
@@ -77,11 +77,13 @@ public final class DefaultLoginViewDelegate: LoginViewDelegate {
     }
     
     private func configureLinksElements(loginView: LoginViewType) {
+        loginView.recoverPasswordLabel?.font = fontPalette.labels
+        loginView.recoverPasswordLabel?.textColor = colorPalette.labels
         loginView.recoverPasswordButton.titleLabel?.font = fontPalette.links
         loginView.recoverPasswordButton.titleLabel?.textColor = colorPalette.links
         
-        loginView.signupLabel.font = fontPalette.labels
-        loginView.signupLabel.textColor = colorPalette.labels
+        loginView.signupLabel?.font = fontPalette.labels
+        loginView.signupLabel?.textColor = colorPalette.labels
         loginView.signupButton.titleLabel?.font = fontPalette.links
         loginView.signupButton.titleLabel?.textColor = colorPalette.links
     }

--- a/Authentication/Login/ViewModel/LoginCredentialsValidator.swift
+++ b/Authentication/Login/ViewModel/LoginCredentialsValidator.swift
@@ -6,9 +6,11 @@
 //  Copyright © 2016 Wolox. All rights reserved.
 //
 
-import Foundation
-
-
+/*
+     Represents a validator for all login fields:
+     email and password.
+     It provides default validators for each of them.
+ */
 public struct LoginCredentialsValidator {
     
     public static func defaultEmailValidator() -> TextInputValidatorType {

--- a/Authentication/SessionServiceType.swift
+++ b/Authentication/SessionServiceType.swift
@@ -20,7 +20,7 @@ public enum SessionServiceEvent<User: UserType> {
     case SignUpError(SessionServiceError)
 }
 
-/**
+/*
      Represents any possible error that may happen
      in the session service through the authentication
      process.
@@ -35,7 +35,7 @@ public protocol SessionServiceType {
     
     associatedtype User: UserType
     
-    /**
+    /*
          The current user logged in in the app.
          
          This will be consulted by the framework to check
@@ -44,13 +44,13 @@ public protocol SessionServiceType {
     */
     var currentUser: AnyProperty<User?> { get }
     
-    /**
+    /*
          ...
          TODO: Check if we need a signal with all this events, or just logout.
     */
     var events: Signal<SessionServiceEvent<User>, NoError> { get }
     
-    /**
+    /*
         This method takes care of validating and logging in.
      
         - Returns: A SignalProducer that can send the User logged in
@@ -67,7 +67,7 @@ public protocol SessionServiceType {
     */
     func logIn(email: Email, password: String) -> SignalProducer<User, SessionServiceError>
     
-    /**
+    /*
          This method takes care of validating and signing up.
          
          - Returns: A SignalProducer that can send the User logged in
@@ -95,7 +95,7 @@ public protocol SessionServiceType {
 
 public extension SessionServiceError {
     
-    /**
+    /*
          The message from an error service is composed by
             a localized message relate to the error type and
             the description of the NSError tat accompanies it, if there is any.

--- a/Authentication/SessionServiceType.swift
+++ b/Authentication/SessionServiceType.swift
@@ -89,7 +89,7 @@ public protocol SessionServiceType {
          Avoid sending a .LogIn event as well.
          Don't forget to update the currentUser.
     */
-    func signUp(name: String, email: Email, password: String) -> SignalProducer<User, SessionServiceError>
+    func signUp(name: String?, email: Email, password: String) -> SignalProducer<User, SessionServiceError>
     
 }
 

--- a/Authentication/SessionServiceType.swift
+++ b/Authentication/SessionServiceType.swift
@@ -11,6 +11,7 @@ import ReactiveCocoa
 import enum Result.NoError
 
 
+//TODO: Check if this is necessary.
 public enum SessionServiceEvent<User: UserType> {
     case LogIn(User)
     case LogOut(User)
@@ -19,6 +20,11 @@ public enum SessionServiceEvent<User: UserType> {
     case SignUpError(SessionServiceError)
 }
 
+/**
+     Represents any possible error that may happen
+     in the session service through the authentication
+     process.
+*/
 public enum SessionServiceError: ErrorType {
     case InvalidLogInCredentials(NSError?)
     case InvalidSignUpCredentials(NSError?)
@@ -29,8 +35,19 @@ public protocol SessionServiceType {
     
     associatedtype User: UserType
     
+    /**
+         The current user logged in in the app.
+         
+         This will be consulted by the framework to check
+         if a user is already logged in or if the
+         authentication process should be triggered.
+    */
     var currentUser: AnyProperty<User?> { get }
     
+    /**
+         ...
+         TODO: Check if we need a signal with all this events, or just logout.
+    */
     var events: Signal<SessionServiceEvent<User>, NoError> { get }
     
     /**
@@ -46,7 +63,7 @@ public protocol SessionServiceType {
         If the credentials aren't valid, the SignalProducer returned
         must take care of:
             sending the error to the observer and
-            sending the login error event through the events signal.
+            sending the login error event through the events signal. -> TODO: Check if we need to demand this.
     */
     func logIn(email: Email, password: String) -> SignalProducer<User, SessionServiceError>
     
@@ -58,26 +75,40 @@ public protocol SessionServiceType {
          If the credentials are valid, the SignalProducer returned
          must take care of:
              sending the user to the observers
-             sending the sign up and the login event through the events signal and
+             sending the sign up event through the events signal and
              updating the currentUser property.
          If the credentials aren't valid, the SignalProducer returned
          must take care of:
              sending the error to the observer and
-             sending the singup error event through the events signal.
+             sending the singup error event through the events signal. -> TODO: Check if we need to demand this.
+        
+         - Attention: The framework implies that a signup action should
+         have the same reaction as a login event: entering the main screen
+         of the app. So just by sending .SignUp event to the signal is
+         enough to trigger this.
+         Avoid sending a .LogIn event as well.
+         Don't forget to update the currentUser.
     */
     func signUp(name: String, email: Email, password: String) -> SignalProducer<User, SessionServiceError>
     
 }
 
 public extension SessionServiceError {
-    var message: String {
+    
+    /**
+         The message from an error service is composed by
+            a localized message relate to the error type and
+            the description of the NSError tat accompanies it, if there is any.
+    */
+    internal var message: String {
         switch self {
         case .InvalidSignUpCredentials(let error):
-            return "signup-error.invalid-credentials.message".localized + (error?.localizedDescription ?? "")
+            return "signup-error.invalid-credentials.message".localized + ". " + (error?.localizedDescription ?? "")
         case .InvalidLogInCredentials(let error):
-            return "login-error.invalid-credentials.message".localized + (error?.localizedDescription ?? "")
+            return "login-error.invalid-credentials.message".localized + ". " + (error?.localizedDescription ?? "")
         case .NetworkError(let error):
-            return "network-error.message".localized + error.localizedDescription
+            return "network-error.message".localized + ". " + error.localizedDescription
         }
     }
+    
 }

--- a/Authentication/SignUp/View/SignupConfiguration.swift
+++ b/Authentication/SignUp/View/SignupConfiguration.swift
@@ -7,7 +7,7 @@
 //
 
 /*
- Protocol for handling transition events occured during signup.
+    Protocol for handling transition events occured during signup.
  */
 public protocol SignupControllerTransitionDelegate {
     
@@ -16,12 +16,12 @@ public protocol SignupControllerTransitionDelegate {
 }
 
 /*
- Class for configuring the signup controller.
- Includes all information required:
- view factory method,
- view model,
- signup controller delegate and
- signup controller transition delegate.
+     Class for configuring the signup controller.
+     Includes all information required:
+         view factory method,
+         view model,
+         signup controller delegate and
+         signup controller transition delegate.
  */
 public final class SignupControllerConfiguration {
     
@@ -31,21 +31,21 @@ public final class SignupControllerConfiguration {
     public let transitionDelegate: SignupControllerTransitionDelegate
     
     /*
-     Initializes a signup controller configuration with the view model,
-     delegate, a factory method for the signup view and transition
-     delegate for the signup controller to use.
-     
-     - Params:
-     - viewModel: view model to bind to and use.
-     - viewFactory: factory method to call only once
-     to get the signup view to use.
-     - transitionDelegate: delegate to handle events that fire a
-     transition, like selecting login.
-     - delegate: delegate which adds behaviour to certain events,
-     like handling a signup error or selecting sign up option.
-     A default delegate is provided.
-     
-     - Returns: A valid configuration
+         Initializes a signup controller configuration with the view model,
+         delegate, a factory method for the signup view and transition
+         delegate for the signup controller to use.
+         
+         - Params:
+             - viewModel: view model to bind to and use.
+             - viewFactory: factory method to call only once
+             to get the signup view to use.
+             - transitionDelegate: delegate to handle events that fire a
+             transition, like selecting login.
+             - delegate: delegate which adds behaviour to certain events,
+             like handling a signup error or selecting sign up option.
+             A default delegate is provided.
+         
+         - Returns: A valid configuration.
      */
     init(viewModel: SignupViewModelType,
         viewFactory: () -> SignupViewType,

--- a/Authentication/SignUp/View/SignupConfiguration.swift
+++ b/Authentication/SignUp/View/SignupConfiguration.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Wolox. All rights reserved.
 //
 
-/**
+/*
  Protocol for handling transition events occured during signup.
  */
 public protocol SignupControllerTransitionDelegate {
@@ -15,7 +15,7 @@ public protocol SignupControllerTransitionDelegate {
     
 }
 
-/**
+/*
  Class for configuring the signup controller.
  Includes all information required:
  view factory method,
@@ -30,7 +30,7 @@ public final class SignupControllerConfiguration {
     public let delegate: SignupControllerDelegate
     public let transitionDelegate: SignupControllerTransitionDelegate
     
-    /**
+    /*
      Initializes a signup controller configuration with the view model,
      delegate, a factory method for the signup view and transition
      delegate for the signup controller to use.

--- a/Authentication/SignUp/View/SignupConfiguration.swift
+++ b/Authentication/SignUp/View/SignupConfiguration.swift
@@ -47,9 +47,7 @@ public final class SignupControllerConfiguration {
      
      - Returns: A valid configuration
      */
-    // swiftlint:disable valid_docs
     init(viewModel: SignupViewModelType,
-    // swiftlint:enable valid_docs
         viewFactory: () -> SignupViewType,
         transitionDelegate: SignupControllerTransitionDelegate,
         delegate: SignupControllerDelegate = DefaultSignupControllerDelegate()) {

--- a/Authentication/SignUp/View/SignupController.swift
+++ b/Authentication/SignUp/View/SignupController.swift
@@ -107,6 +107,7 @@ private extension SignupController {
                 } else {
                     self._delegate.didFailNameValidation(self, with: errors)
                 }
+                self.signupView.usernameTextFieldValid = errors.isEmpty
             }
             if let nameValidationMessageLabel = signupView.usernameValidationMessageLabel {
                 nameValidationMessageLabel.rex_text <~ _viewModel.nameValidationErrors.signal.map { $0.first ?? " " }
@@ -123,6 +124,7 @@ private extension SignupController {
             } else {
                 self._delegate.didFailEmailValidation(self, with: errors)
             }
+            self.signupView.emailTextFieldValid = errors.isEmpty
         }
         if let emailValidationMessageLabel = signupView.emailValidationMessageLabel {
             emailValidationMessageLabel.rex_text <~ _viewModel.emailValidationErrors.signal.map { $0.first ?? " " }
@@ -140,6 +142,7 @@ private extension SignupController {
             } else {
                 self._delegate.didFailPasswordValidation(self, with: errors)
             }
+            self.signupView.passwordTextFieldValid = errors.isEmpty
         }
         if let passwordValidationMessageLabel = signupView.passwordValidationMessageLabel {
             passwordValidationMessageLabel.rex_text <~ _viewModel.passwordValidationErrors.signal.map { $0.first ?? " " }
@@ -163,6 +166,7 @@ private extension SignupController {
                 } else {
                     self._delegate.didFailPasswordConfirmationValidation(self, with: errors)
                 }
+                self.signupView.passwordConfirmationTextFieldValid = errors.isEmpty
             }
             if let passwordConfirmValidationMessageLabel = signupView.passwordConfirmValidationMessageLabel {
                 passwordConfirmValidationMessageLabel.rex_text <~ _viewModel.passwordConfirmationValidationErrors.signal.map { $0.first ?? " " }

--- a/Authentication/SignUp/View/SignupController.swift
+++ b/Authentication/SignUp/View/SignupController.swift
@@ -17,9 +17,9 @@ import ReactiveCocoa
      If there are more than one validation error in a field, the controller
      presents only the first one in the errors label.
      
-     If wanting to use the default SignupController, you should not override
-     the `createSignupController` method of the Bootstrapper, but all the others
-     that provide the elements this controller uses. (That is to say,
+     If wanting to use the default SignupController with some customization,
+     you should not override the `createSignupController` method of the Bootstrapper,
+     but all the others that provide the elements this controller uses. (That is to say,
      `createSignupView`, `createSignupViewModel`, `createSignupControllerDelegate`
      and/or `createSignupControllerConfiguration`)
  */

--- a/Authentication/SignUp/View/SignupController.swift
+++ b/Authentication/SignUp/View/SignupController.swift
@@ -8,6 +8,21 @@
 
 import ReactiveCocoa
 
+
+/*
+     Signup View Controller that takes care of managing the signup, from
+     validating all fields, to binding a signup view to the view model
+     and informing the signup controller delegate when certain events 
+     occur for it to act upon them.
+     If there are more than one validation error in a field, the controller
+     presents only the first one in the errors label.
+     
+     If wanting to use the default SignupController, you should not override
+     the `createSignupController` method of the Bootstrapper, but all the others
+     that provide the elements this controller uses. (That is to say,
+     `createSignupView`, `createSignupViewModel`, `createSignupControllerDelegate`
+     and/or `createSignupControllerConfiguration`)
+ */
 public final class SignupController: UIViewController {
     
     private let _viewModel: SignupViewModelType
@@ -23,10 +38,15 @@ public final class SignupController: UIViewController {
     private let _activeTextField = MutableProperty<UITextField?>(.None)
 
     
-    // Internal initializer, because if wanting to use the  default SignupController,
-    // you should not override the `createSignupController` method, but all the others 
-    // that provide the elements this controller uses. (That is to say,
-    // `createSignupView`, `createSignupViewModel`, `createSignupControllerDelegate`)
+    /*
+         Initializes a signup controller with the configuration to use.
+         
+         Parameters:
+         - configuration: A signup controller configuration with all
+         elements needed to operate.
+         
+         - Returns: A valid signup view controller ready to use.
+     */
     internal init(configuration: SignupControllerConfiguration) {
         _viewModel = configuration.viewModel
         _signupViewFactory = configuration.viewFactory

--- a/Authentication/SignUp/View/SignupController.swift
+++ b/Authentication/SignUp/View/SignupController.swift
@@ -86,6 +86,8 @@ private extension SignupController {
         bindEmailElements()
         bindPasswordElements()
         bindButtons()
+        checkTextFieldsSelection()
+        hideUnselectedTextfields()
         setTextfieldOrder()
         
         _viewModel.signUpExecuting.observeNext { [unowned self] executing in
@@ -189,12 +191,32 @@ private extension SignupController {
     private func setTextfieldOrder() {
         signupView.usernameTextField?.nextTextField = signupView.emailTextField
         signupView.emailTextField.nextTextField = signupView.passwordTextField
-        signupView.passwordTextField.nextTextField = signupView.passwordConfirmTextField ?? signupView.usernameTextField ?? signupView.emailTextField
-        signupView.passwordConfirmTextField?.nextTextField = signupView.usernameTextField ?? signupView.emailTextField
+        signupView.passwordTextField.nextTextField = _viewModel.passwordConfirmationEnabled ? signupView.passwordConfirmTextField
+            : (_viewModel.usernameEnabled ? signupView.usernameTextField : signupView.emailTextField)
+        signupView.passwordConfirmTextField?.nextTextField = _viewModel.usernameEnabled ? signupView.usernameTextField : signupView.emailTextField
+        lastTextField.returnKeyType = .Go
     }
     
     private var lastTextField: UITextField {
-        return signupView.passwordConfirmTextField ?? signupView.passwordTextField
+        return _viewModel.passwordConfirmationEnabled ? signupView.passwordConfirmTextField! : signupView.passwordTextField
+    }
+    
+    private func hideUnselectedTextfields() {
+        if !_viewModel.usernameEnabled {
+            signupView.hideUsernameElements()
+        }
+        if !_viewModel.passwordConfirmationEnabled {
+            signupView.hidePasswordConfirmElements()
+        }
+    }
+    
+    private func checkTextFieldsSelection() {
+        if _viewModel.usernameEnabled && signupView.usernameTextField == .None {
+            //fatalError?
+        }
+        if _viewModel.passwordConfirmationEnabled && signupView.passwordConfirmTextField == .None {
+            //fatalError?
+        }
     }
     
 }

--- a/Authentication/SignUp/View/SignupControllerDelegate.swift
+++ b/Authentication/SignUp/View/SignupControllerDelegate.swift
@@ -6,40 +6,73 @@
 //  Copyright © 2016 Wolox. All rights reserved.
 //
 
-import Foundation
 
+/*
+     Protocol for signup controller delegates.
+     Create your own delegate and override any of
+     the defaut methods to add behaviour to your
+     singup process.
+ */
 public protocol SignupControllerDelegate {
     
+    /* Property indicating if the signup errors
+     should be shown with an alert, apart from
+     the signup errors label if it exists. */
     var shouldDisplaySignupErrorWithAlert: Bool { get }
     
+    /* Function called when the signup action begins executing,
+       before setting the `signUpButtonPressed` property of the view used. */
     func willExecuteSignUp(controller: SignupController)
     
+    /* Function called when the signup action ended with success,
+       before setting the `signUpButtonPressed` property of the view used. */
     func didExecuteSignUp(controller: SignupController)
     
+    /* Function called when the signup action ended with error,
+       before setting the `signUpButtonPressed` property of the view used. */
     func didSignUp(controller: SignupController, with error: SessionServiceError)
     
+    /* Function called when any new username introduced is valid,
+       before setting the `usernameTextFieldValid` property of the view used. */
     func didPassNameValidation(controller: SignupController)
     
+    /* Function called when any new username introduced is invalid,
+       before setting the `usernameTextFieldValid` property of the view used. */
     func didFailNameValidation(controller: SignupController, with errors: [String])
     
+    /* Function called when any new email introduced is valid,
+       before setting the `emailTextFieldValid` property of the view used. */
     func didPassEmailValidation(controller: SignupController)
     
+    /* Function called when any new email introduced is invalid,
+       before setting the `emailTextFieldValid` property of the view used. */
     func didFailEmailValidation(controller: SignupController, with errors: [String])
     
+    /* Function called when any new password introduced is valid,
+       before setting the `passwordTextFieldValid` property of the view used. */
     func didPassPasswordValidation(controller: SignupController)
     
+    /* Function called when any new password introduced is invalid,
+       before setting the `passwordTextFieldValid` property of the view used. */
     func didFailPasswordValidation(controller: SignupController, with errors: [String])
 
+    /* Function called when any new password confirmation introduced is valid,
+       before setting the `passwordConfirmationTextFieldValid` property of the view used. */
     func didPassPasswordConfirmationValidation(controller: SignupController)
     
+    /* Function called when any new password confirmation introduced is invalid,
+       before setting the `passwordConfirmationTextFieldValid` property of the view used. */
     func didFailPasswordConfirmationValidation(controller: SignupController, with errors: [String])
     
 }
 
 extension SignupControllerDelegate {
     
+    /* By default, true. */
     public var shouldDisplaySignupErrorWithAlert: Bool { return true }
     
+    /* By default, it clears old errors from label and
+       activates the Network Activity Indicator in the status bar. */
     public func willExecuteSignUp(controller: SignupController) {
         if let errorLabel = controller.signupView.signUpErrorLabel {
             errorLabel.text = " "
@@ -48,12 +81,18 @@ extension SignupControllerDelegate {
         app.networkActivityIndicatorVisible = true
     }
     
+    /* By default, it deactivates the Network Activity Indicator in the status bar. */
     public func didExecuteSignUp(controller: SignupController) {
         let app = UIApplication.sharedApplication()
         app.networkActivityIndicatorVisible = false
     }
     
+    /* By default, it deactivates the Network Activity Indicator in the status bar,
+     fills the error label with the error message and if the property
+     `shouldDisplaySignupErrorWithAlert` is set to true, shows an alert with the error. */
     public func didSignUp(controller: SignupController, with error: SessionServiceError) {
+        let app = UIApplication.sharedApplication()
+        app.networkActivityIndicatorVisible = false
         if let errorLabel = controller.signupView.signUpErrorLabel {
             errorLabel.text = error.message
         }
@@ -64,37 +103,29 @@ extension SignupControllerDelegate {
         }
     }
     
-    public func didPassNameValidation(controller: SignupController) {
-        controller.signupView.usernameTextFieldValid = true
-    }
+    /* By default, it does nothing. */
+    public func didPassNameValidation(controller: SignupController) { }
     
-    public func didFailNameValidation(controller: SignupController, with errors: [String]) {
-        controller.signupView.usernameTextFieldValid = false
-    }
+    /* By default, it does nothing. */
+    public func didFailNameValidation(controller: SignupController, with errors: [String]) { }
     
-    public func didPassEmailValidation(controller: SignupController) {
-        controller.signupView.emailTextFieldValid = true
-    }
+    /* By default, it does nothing. */
+    public func didPassEmailValidation(controller: SignupController) { }
     
-    public func didFailEmailValidation(controller: SignupController, with errors: [String]) {
-        controller.signupView.emailTextFieldValid = false
-    }
+    /* By default, it does nothing. */
+    public func didFailEmailValidation(controller: SignupController, with errors: [String]) { }
     
-    public func didPassPasswordValidation(controller: SignupController) {
-        controller.signupView.passwordTextFieldValid = true
-    }
+    /* By default, it does nothing. */
+    public func didPassPasswordValidation(controller: SignupController) { }
     
-    public func didFailPasswordValidation(controller: SignupController, with errors: [String]) {
-        controller.signupView.passwordTextFieldValid = false
-    }
+    /* By default, it does nothing. */
+    public func didFailPasswordValidation(controller: SignupController, with errors: [String]) { }
     
-    public func didPassPasswordConfirmationValidation(controller: SignupController) {
-        controller.signupView.passwordConfirmationTextFieldValid = true
-    }
+    /* By default, it does nothing. */
+    public func didPassPasswordConfirmationValidation(controller: SignupController) { }
     
-    public func didFailPasswordConfirmationValidation(controller: SignupController, with errors: [String]) {
-        controller.signupView.passwordConfirmationTextFieldValid = false
-    }
+    /* By default, it does nothing. */
+    public func didFailPasswordConfirmationValidation(controller: SignupController, with errors: [String]) { }
     
 }
 

--- a/Authentication/SignUp/View/SignupControllerDelegate.swift
+++ b/Authentication/SignUp/View/SignupControllerDelegate.swift
@@ -129,4 +129,8 @@ extension SignupControllerDelegate {
     
 }
 
+/*
+     The default signup controller delegate operates with the
+     default behaviour of the SignupControllerDelegate protocol's methods.
+ */
 public final class DefaultSignupControllerDelegate: SignupControllerDelegate { }

--- a/Authentication/SignUp/View/SignupView.swift
+++ b/Authentication/SignUp/View/SignupView.swift
@@ -143,14 +143,8 @@ internal final class SignupView: UIView, SignupViewType, NibLoadable {
         }
     }
     
-    internal var termsAndServicesLabel: UILabel? { return termsAndServicesLabelOutlet }
-    @IBOutlet weak var termsAndServicesLabelOutlet: UILabel! {
-        didSet { termsAndServicesLabelOutlet.text = termsAndServicesLabelText }
-    }
-    internal var termsAndServicesButton: UIButton { return termsAndServicesButtonOutlet }
-    @IBOutlet weak var termsAndServicesButtonOutlet: UIButton! {
-        didSet { termsAndServicesButtonOutlet.setTitle(termsAndServicesButtonTitle, forState: .Normal) }
-    }
+    internal var termsAndServicesTextView: UITextView { return termsAndServicesTextViewOutlet }
+    @IBOutlet weak var termsAndServicesTextViewOutlet: UITextView!
     
     internal var loginLabel: UILabel? { return loginLabelOutlet }
     @IBOutlet weak var loginLabelOutlet: UILabel! {
@@ -208,6 +202,7 @@ internal final class SignupView: UIView, SignupViewType, NibLoadable {
         passwordVisible = false
         confirmationPasswordVisible = false
         
+        setTermsAndConditionsText()
         delegate.configureView(self)
     }
     
@@ -357,6 +352,23 @@ private extension SignupView {
         passwordConfirmationErrorsView?.hidden = true
     }
     
+    private func setTermsAndConditionsText() {
+        let textString = NSString(string: termsAndServicesText)
+        let textWithLinks = NSMutableAttributedString(string: textString as String)
+        
+        let termsString = termsAndServicesLinkText
+        let termsURL = NSURL(string: termsAndServicesLinkURL)!
+        let termsRange = textString.rangeOfString(termsString)
+        
+        textWithLinks.addAttribute(NSLinkAttributeName, value: termsURL, range: termsRange)
+        
+        termsAndServicesTextView.attributedText = textWithLinks
+        termsAndServicesTextView.linkTextAttributes = [NSForegroundColorAttributeName: delegate.colorPalette.links,
+                                                       NSUnderlineColorAttributeName: delegate.colorPalette.links,
+                                                       NSUnderlineStyleAttributeName: NSUnderlineStyle.StyleSingle.rawValue]
+        termsAndServicesTextView.textAlignment = .Center
+    }
+    
 }
 
 public extension SignupViewType {
@@ -383,9 +395,11 @@ public extension SignupViewType {
     
     public var confirmPasswordVisibilityButtonTitle: String { return ("text-visibility-button-title." + (confirmationPasswordVisible ? "false" : "true")).localized }
     
-    public var termsAndServicesLabelText: String { return "signup-view.terms-and-services.label-text".localized }
+    public var termsAndServicesText: String { return "signup-view.terms-and-services.text".localized }
     
-    public var termsAndServicesButtonTitle: String { return "signup-view.terms-and-services.button-title".localized }
+    public var termsAndServicesLinkText: String { return "signup-view.terms-and-services.link-text".localized }
+    
+    public var termsAndServicesLinkURL: String { return "signup-view.terms-and-services.link-url".localized }
     
     public var signUpButtonTitle: String { return "signup-view.signup-button-title".localized }
     

--- a/Authentication/SignUp/View/SignupView.swift
+++ b/Authentication/SignUp/View/SignupView.swift
@@ -38,7 +38,30 @@ internal final class SignupView: UIView, SignupViewType, NibLoadable {
         didSet { titleLabel.text = titleText }
     }
     
-    internal var usernameErrorsView: UIView?
+    
+    
+    internal var usernameTextField: UITextField? { return usernameTextFieldOutlet }
+    @IBOutlet weak var usernameTextFieldOutlet: UITextField! {
+        didSet { usernameTextFieldOutlet.placeholder = namePlaceholderText }
+    }
+    
+    @IBOutlet weak var usernameTextFieldViewOutlet: UIView! {
+        didSet {
+            usernameTextFieldViewOutlet.layer.borderWidth = 1
+            usernameTextFieldViewOutlet.layer.cornerRadius = 6.0
+        }
+    }
+    
+    internal var usernameValidationMessageLabel: UILabel? { return usernameValidationMessageLabelOutlet }
+    @IBOutlet weak var usernameValidationMessageLabelOutlet: UILabel! {
+        didSet { usernameValidationMessageLabelOutlet.text = " " }
+    }
+    
+    @IBOutlet weak var usernameErrorsView: UIView!
+    @IBOutlet weak var usernameView: UIView!
+    @IBOutlet weak var usernameHeightConstraint: NSLayoutConstraint!
+    
+    
     
     internal var emailTextField: UITextField { return emailTextFieldOutlet }
     @IBOutlet weak var emailTextFieldOutlet: UITextField! {
@@ -59,6 +82,8 @@ internal final class SignupView: UIView, SignupViewType, NibLoadable {
     
     @IBOutlet weak var emailErrorsView: UIView!
 
+    
+    
     internal var passwordTextField: UITextField { return passwordTextFieldOutlet }
     @IBOutlet weak var passwordTextFieldOutlet: UITextField! {
         didSet { passwordTextFieldOutlet.placeholder = passwordPlaceholderText }
@@ -82,7 +107,33 @@ internal final class SignupView: UIView, SignupViewType, NibLoadable {
     
     @IBOutlet weak var passwordErrorsView: UIView!
 
-    internal var passwordConfirmationErrorsView: UIView?
+    
+    
+    internal var passwordConfirmTextField: UITextField? { return passwordConfirmTextFieldOutlet }
+    @IBOutlet weak var passwordConfirmTextFieldOutlet: UITextField! {
+        didSet { passwordConfirmTextFieldOutlet.placeholder = confirmPasswordPlaceholderText }
+    }
+    @IBOutlet weak var pswdConfirmTextFieldAndButtonViewOutlet: UIView! {
+        didSet {
+            pswdConfirmTextFieldAndButtonViewOutlet.layer.borderWidth = 1
+            pswdConfirmTextFieldAndButtonViewOutlet.layer.cornerRadius = 6.0
+        }
+    }
+    
+    internal var passwordConfirmValidationMessageLabel: UILabel? { return pswdConfirmValidationMessageLabelOutlet }
+    @IBOutlet weak var pswdConfirmValidationMessageLabelOutlet: UILabel! {
+        didSet { pswdConfirmValidationMessageLabelOutlet.text = " " }
+    }
+    
+    internal var passwordConfirmVisibilityButton: UIButton? { return passwordConfirmVisibilityButtonOutlet }
+    @IBOutlet weak var passwordConfirmVisibilityButtonOutlet: UIButton! {
+        didSet { passwordConfirmVisibilityButtonOutlet.hidden = true }
+    }
+    
+    @IBOutlet weak var passwordConfirmationErrorsView: UIView!
+    @IBOutlet weak var passwordConfirmationView: UIView!
+    @IBOutlet weak var passwordConfirmationHeightConstraint: NSLayoutConstraint!
+    
     
     internal var signUpButton: UIButton { return signUpButtonOutlet }
     @IBOutlet weak var signUpButtonOutlet: UIButton! {
@@ -128,6 +179,18 @@ internal final class SignupView: UIView, SignupViewType, NibLoadable {
     internal var signUpButtonEnabled = false { didSet { signUpButtonEnabledWasSet() } }
     internal var signUpButtonPressed = false { didSet { signUpButtonPressedWasSet() } }
     
+    
+    internal func hideUsernameElements() {
+        usernameHeightConstraint.active = false
+        usernameView.hidden = true
+    }
+    
+    
+    internal func hidePasswordConfirmElements() {
+        passwordConfirmationHeightConstraint.active = false
+        passwordConfirmationView.hidden = true
+    }
+    
     internal func render() {
         usernameTextFieldValid = true
         emailTextFieldValid = true
@@ -157,22 +220,23 @@ private extension SignupView {
             let color: CGColor
             if usernameTextFieldValid {
                 color = delegate.colorPalette.textfieldsNormal.CGColor
-                usernameErrorsView?.hidden = true
+                usernameErrorsView.hidden = true
             } else {
                 color = delegate.colorPalette.textfieldsError.CGColor
-                usernameErrorsView?.hidden = false
+                usernameErrorsView.hidden = false
             }
-            usernameTextField?.layer.borderColor = color
+            usernameTextFieldViewOutlet.layer.borderColor = color
         } else {
-            usernameErrorsView?.hidden = true
+            usernameErrorsView.hidden = true
         }
     }
     
     private func usernameTextFieldSelectedWasSet() {
         if usernameTextFieldSelected {
-            usernameTextField?.layer.borderColor = delegate.colorPalette.textfieldsSelected.CGColor
-            usernameErrorsView?.hidden = true
+            usernameTextFieldOutlet.layer.borderColor = delegate.colorPalette.textfieldsSelected.CGColor
+            usernameErrorsView.hidden = true
         } else {
+            // To trigger the Valid's didSet.
             let valid = usernameTextFieldValid
             usernameTextFieldValid = valid
         }
@@ -199,6 +263,7 @@ private extension SignupView {
             emailTextFieldViewOutlet.layer.borderColor = delegate.colorPalette.textfieldsSelected.CGColor
             emailErrorsView.hidden = true
         } else {
+            // To trigger the Valid's didSet.
             let valid = emailTextFieldValid
             emailTextFieldValid = valid
         }
@@ -225,6 +290,7 @@ private extension SignupView {
             passwordTextFieldAndButtonViewOutlet.layer.borderColor = delegate.colorPalette.textfieldsSelected.CGColor
             passwordErrorsView.hidden = true
         } else {
+            // To trigger the Valid's didSet.
             let valid = passwordTextFieldValid
             passwordTextFieldValid = valid
         }
@@ -244,22 +310,23 @@ private extension SignupView {
             let color: CGColor
             if passwordConfirmationTextFieldValid {
                 color = delegate.colorPalette.textfieldsNormal.CGColor
-                passwordConfirmationErrorsView?.hidden = true
+                passwordConfirmationErrorsView.hidden = true
             } else {
                 color = delegate.colorPalette.textfieldsError.CGColor
-                passwordConfirmationErrorsView?.hidden = false
+                passwordConfirmationErrorsView.hidden = false
             }
-            passwordConfirmTextField?.layer.borderColor = color
+            pswdConfirmTextFieldAndButtonViewOutlet.layer.borderColor = color
         } else {
-            passwordConfirmationErrorsView?.hidden = true
+            passwordConfirmationErrorsView.hidden = true
         }
     }
     
     private func passwordConfirmationTextFieldSelectedWasSet() {
         if passwordConfirmationTextFieldSelected {
-            passwordConfirmTextField?.layer.borderColor = delegate.colorPalette.textfieldsSelected.CGColor
-            passwordConfirmationErrorsView?.hidden = true
+            passwordConfirmTextFieldOutlet.layer.borderColor = delegate.colorPalette.textfieldsSelected.CGColor
+            passwordConfirmationErrorsView.hidden = true
         } else {
+            // To trigger the Valid's didSet.
             let valid = passwordConfirmationTextFieldValid
             passwordConfirmationTextFieldValid = valid
         }
@@ -294,68 +361,36 @@ private extension SignupView {
 
 public extension SignupViewType {
     
-    public var titleText: String {
-        return "signup-view.title".localized
-    }
+    public var titleText: String { return "signup-view.title".localized }
     
-    public var nameText: String {
-        return "signup-view.name".localized
-    }
+    public var nameText: String { return "signup-view.name".localized }
     
-    public var emailText: String {
-        return "signup-view.email".localized
-    }
+    public var emailText: String { return "signup-view.email".localized }
     
-    public var passwordText: String {
-        return "signup-view.password".localized
-    }
+    public var passwordText: String { return "signup-view.password".localized }
     
-    public var confirmPasswordText: String {
-        return "signup-view.confirm-password".localized
-    }
+    public var confirmPasswordText: String { return "signup-view.confirm-password".localized }
     
-    public var namePlaceholderText: String {
-        return "signup-view.name-placeholder".localized
-    }
+    public var namePlaceholderText: String { return "signup-view.name-placeholder".localized}
     
-    public var emailPlaceholderText: String {
-        return "signup-view.email-placeholder".localized
-    }
+    public var emailPlaceholderText: String { return "signup-view.email-placeholder".localized }
     
-    public var passwordPlaceholderText: String {
-        return "signup-view.password-placeholder".localized
-    }
+    public var passwordPlaceholderText: String { return "signup-view.password-placeholder".localized }
     
-    public var confirmPasswordPlaceholderText: String {
-        return "signup-view.confirm-password-placeholder".localized
-    }
+    public var confirmPasswordPlaceholderText: String { return "signup-view.confirm-password-placeholder".localized }
     
-    public var passwordVisibilityButtonTitle: String {
-        return ("text-visibility-button-title." + (passwordVisible ? "false" : "true")).localized
-    }
+    public var passwordVisibilityButtonTitle: String { return ("text-visibility-button-title." + (passwordVisible ? "false" : "true")).localized }
     
-    public var confirmPasswordVisibilityButtonTitle: String {
-        return ("text-visibility-button-title." + (confirmationPasswordVisible ? "false" : "true")).localized
-    }
+    public var confirmPasswordVisibilityButtonTitle: String { return ("text-visibility-button-title." + (confirmationPasswordVisible ? "false" : "true")).localized }
     
-    public var termsAndServicesLabelText: String {
-        return "signup-view.terms-and-services.label-text".localized
-    }
+    public var termsAndServicesLabelText: String { return "signup-view.terms-and-services.label-text".localized }
     
-    public var termsAndServicesButtonTitle: String {
-        return "signup-view.terms-and-services.button-title".localized
-    }
+    public var termsAndServicesButtonTitle: String { return "signup-view.terms-and-services.button-title".localized }
     
-    public var signUpButtonTitle: String {
-        return "signup-view.signup-button-title".localized
-    }
+    public var signUpButtonTitle: String { return "signup-view.signup-button-title".localized }
     
-    public var loginLabelText: String {
-        return "signup-view.login.label-text".localized
-    }
+    public var loginLabelText: String { return "signup-view.login.label-text".localized }
     
-    public var loginButtonTitle: String {
-        return "signup-view.login.button-title".localized
-    }
+    public var loginButtonTitle: String { return "signup-view.login.button-title".localized }
     
 }

--- a/Authentication/SignUp/View/SignupView.swift
+++ b/Authentication/SignUp/View/SignupView.swift
@@ -22,6 +22,12 @@ public protocol SignupViewType: Renderable, SignupFormType {
     
 }
 
+public extension SignupViewType {
+    
+    var loginLabel: UILabel? { return .None }
+    
+}
+
 /* Default signup view. */
 internal final class SignupView: UIView, SignupViewType, NibLoadable {
     
@@ -31,13 +37,8 @@ internal final class SignupView: UIView, SignupViewType, NibLoadable {
     @IBOutlet weak var titleLabelOutlet: UILabel! {
         didSet { titleLabel.text = titleText }
     }
-
-    internal var usernameLabel: UILabel?
-    internal var usernameTextField: UITextField?
-    internal var usernameValidationMessageLabel: UILabel?
-    internal var usernameErrorsView: UIView?
     
-    internal var emailLabel: UILabel?
+    internal var usernameErrorsView: UIView?
     
     internal var emailTextField: UITextField { return emailTextFieldOutlet }
     @IBOutlet weak var emailTextFieldOutlet: UITextField! {
@@ -57,8 +58,6 @@ internal final class SignupView: UIView, SignupViewType, NibLoadable {
     }
     
     @IBOutlet weak var emailErrorsView: UIView!
-    
-    internal var passwordLabel: UILabel?
 
     internal var passwordTextField: UITextField { return passwordTextFieldOutlet }
     @IBOutlet weak var passwordTextFieldOutlet: UITextField! {
@@ -83,10 +82,6 @@ internal final class SignupView: UIView, SignupViewType, NibLoadable {
     
     @IBOutlet weak var passwordErrorsView: UIView!
 
-    internal var passwordConfirmLabel: UILabel?
-    internal var passwordConfirmTextField: UITextField?
-    internal var passwordConfirmValidationMessageLabel: UILabel?
-    internal var passwordConfirmVisibilityButton: UIButton?
     internal var passwordConfirmationErrorsView: UIView?
     
     internal var signUpButton: UIButton { return signUpButtonOutlet }
@@ -96,7 +91,6 @@ internal final class SignupView: UIView, SignupViewType, NibLoadable {
             signUpButtonOutlet.setTitle(signUpButtonTitle, forState: .Normal)
         }
     }
-    internal var signUpErrorLabel: UILabel? { return .None }
     
     internal var termsAndServicesLabel: UILabel? { return termsAndServicesLabelOutlet }
     @IBOutlet weak var termsAndServicesLabelOutlet: UILabel! {

--- a/Authentication/SignUp/View/SignupView.swift
+++ b/Authentication/SignUp/View/SignupView.swift
@@ -6,15 +6,23 @@
 //  Copyright © 2016 Wolox. All rights reserved.
 //
 
+/*
+     Represents the minimum required
+     properties from a signup view
+     for it to be compatible with
+     the framework.
+ */
 public protocol SignupViewType: Renderable, SignupFormType {
 
     var titleLabel: UILabel { get }
     
-    var loginLabel: UILabel { get }
+    /* Navigation elements to other screens */
+    var loginLabel: UILabel? { get }
     var loginButton: UIButton { get }
     
 }
 
+/* Default signup view. */
 internal final class SignupView: UIView, SignupViewType, NibLoadable {
     
     internal lazy var delegate: SignupViewDelegate = DefaultSignupViewDelegate()
@@ -99,7 +107,7 @@ internal final class SignupView: UIView, SignupViewType, NibLoadable {
         didSet { termsAndServicesButtonOutlet.setTitle(termsAndServicesButtonTitle, forState: .Normal) }
     }
     
-    internal var loginLabel: UILabel { return loginLabelOutlet }
+    internal var loginLabel: UILabel? { return loginLabelOutlet }
     @IBOutlet weak var loginLabelOutlet: UILabel! {
         didSet { loginLabelOutlet.text = loginLabelText }
     }

--- a/Authentication/SignUp/View/SignupView.swift
+++ b/Authentication/SignUp/View/SignupView.swift
@@ -153,7 +153,7 @@ internal final class SignupView: UIView, SignupViewType, NibLoadable {
     
     internal var loginButton: UIButton { return loginButtonOutlet }
     @IBOutlet weak var loginButtonOutlet: UIButton! {
-        didSet { loginButtonOutlet.setTitle(loginButtonTitle, forState: .Normal) }
+        didSet { loginButtonOutlet.setUnderlinedTitle(loginButtonTitle) }
     }
     
     internal var usernameTextFieldValid = false { didSet { usernameTextFieldValidWasSet() } }

--- a/Authentication/SignUp/View/SignupView.xib
+++ b/Authentication/SignUp/View/SignupView.xib
@@ -101,8 +101,8 @@
                                     </constraints>
                                     <variation key="default">
                                         <mask key="constraints">
-                                            <exclude reference="viJ-OK-ie5"/>
                                             <exclude reference="4o4-77-gqq"/>
+                                            <exclude reference="viJ-OK-ie5"/>
                                         </mask>
                                     </variation>
                                 </view>
@@ -338,45 +338,25 @@
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="X8o-uo-260" userLabel="Terms&amp;Serivces View">
                             <rect key="frame" x="0.0" y="0.0" width="418" height="82"/>
                             <subviews>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5rz-BZ-aoM">
-                                    <rect key="frame" x="111" y="20" width="197" height="42"/>
-                                    <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="I accept" textAlignment="right" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ysg-6j-g6B">
-                                            <rect key="frame" x="0.0" y="0.0" width="55" height="42"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JuJ-8k-i6o">
-                                            <rect key="frame" x="65" y="0.0" width="132" height="42"/>
-                                            <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="15"/>
-                                            <state key="normal" title="Terms and Services"/>
-                                        </button>
-                                    </subviews>
+                                <textView clipsSubviews="YES" contentMode="scaleAspectFill" bounces="NO" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" delaysContentTouches="NO" canCancelContentTouches="NO" bouncesZoom="NO" editable="NO" text="I accept the Terms and Services" textAlignment="center" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mcI-Oe-1fg">
+                                    <rect key="frame" x="21" y="20" width="376" height="42"/>
                                     <constraints>
-                                        <constraint firstItem="ysg-6j-g6B" firstAttribute="leading" secondItem="5rz-BZ-aoM" secondAttribute="leading" id="6JA-Tf-Skh"/>
-                                        <constraint firstItem="ysg-6j-g6B" firstAttribute="top" secondItem="5rz-BZ-aoM" secondAttribute="top" id="84C-bh-GWa"/>
-                                        <constraint firstItem="JuJ-8k-i6o" firstAttribute="leading" secondItem="ysg-6j-g6B" secondAttribute="trailing" constant="10" id="DUT-EY-Fgs"/>
-                                        <constraint firstItem="JuJ-8k-i6o" firstAttribute="top" secondItem="5rz-BZ-aoM" secondAttribute="top" constant="3" id="Fbf-MO-e4C"/>
-                                        <constraint firstItem="JuJ-8k-i6o" firstAttribute="bottom" secondItem="ysg-6j-g6B" secondAttribute="bottom" id="Zd7-sp-i6r"/>
-                                        <constraint firstItem="JuJ-8k-i6o" firstAttribute="top" secondItem="ysg-6j-g6B" secondAttribute="top" id="hFy-s8-pjM"/>
-                                        <constraint firstAttribute="bottom" secondItem="ysg-6j-g6B" secondAttribute="bottom" id="kli-7x-SGO"/>
-                                        <constraint firstAttribute="trailing" secondItem="JuJ-8k-i6o" secondAttribute="trailing" id="pRX-0W-ppo"/>
-                                        <constraint firstAttribute="bottom" secondItem="JuJ-8k-i6o" secondAttribute="bottom" id="zHW-yt-SRj"/>
+                                        <constraint firstAttribute="height" constant="40" id="LJ8-l9-nBu"/>
                                     </constraints>
+                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                    <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                     <variation key="default">
                                         <mask key="constraints">
-                                            <exclude reference="Fbf-MO-e4C"/>
-                                            <exclude reference="zHW-yt-SRj"/>
+                                            <exclude reference="LJ8-l9-nBu"/>
                                         </mask>
                                     </variation>
-                                </view>
+                                </textView>
                             </subviews>
                             <constraints>
-                                <constraint firstAttribute="bottom" secondItem="5rz-BZ-aoM" secondAttribute="bottom" constant="20" id="CUL-vJ-GsJ"/>
+                                <constraint firstItem="mcI-Oe-1fg" firstAttribute="centerY" secondItem="X8o-uo-260" secondAttribute="centerY" id="8kC-cw-CTC"/>
                                 <constraint firstAttribute="height" constant="82" id="L0b-2v-3fr"/>
-                                <constraint firstItem="5rz-BZ-aoM" firstAttribute="top" secondItem="X8o-uo-260" secondAttribute="top" constant="20" id="LFC-mg-cXC"/>
-                                <constraint firstItem="5rz-BZ-aoM" firstAttribute="centerX" secondItem="X8o-uo-260" secondAttribute="centerX" id="iW9-FP-8fP"/>
+                                <constraint firstAttribute="bottom" secondItem="mcI-Oe-1fg" secondAttribute="bottom" constant="20" id="X3i-G5-wmn"/>
+                                <constraint firstItem="mcI-Oe-1fg" firstAttribute="top" secondItem="X8o-uo-260" secondAttribute="top" constant="20" id="ie2-0M-SnX"/>
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6RS-Mz-klY" userLabel="Button View">
@@ -457,9 +437,11 @@
                 <constraint firstItem="YZp-rK-32z" firstAttribute="trailing" secondItem="OcG-29-7E9" secondAttribute="trailing" id="N5A-O6-UQh"/>
                 <constraint firstItem="YZp-rK-32z" firstAttribute="height" secondItem="iN0-l3-epB" secondAttribute="height" multiplier="56/671" id="OA0-y1-LDP"/>
                 <constraint firstItem="pSa-0q-elf" firstAttribute="top" secondItem="lPU-cw-qqE" secondAttribute="bottom" constant="10" id="OE6-Ur-KWl"/>
+                <constraint firstItem="OcG-29-7E9" firstAttribute="leading" secondItem="mcI-Oe-1fg" secondAttribute="leading" id="VBb-sg-iEB"/>
                 <constraint firstItem="Iqv-fj-4Xd" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="WtO-SA-rte"/>
                 <constraint firstAttribute="trailing" secondItem="Iqv-fj-4Xd" secondAttribute="trailing" id="bCd-JD-6j7"/>
                 <constraint firstItem="lPU-cw-qqE" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="20" id="cNL-Df-ANF"/>
+                <constraint firstItem="OcG-29-7E9" firstAttribute="trailing" secondItem="mcI-Oe-1fg" secondAttribute="trailing" id="gR7-rM-CTH"/>
                 <constraint firstItem="Iqv-fj-4Xd" firstAttribute="top" secondItem="pSa-0q-elf" secondAttribute="bottom" id="hiQ-ur-uol"/>
                 <constraint firstItem="lPU-cw-qqE" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="kX9-eB-Uo4"/>
                 <constraint firstAttribute="trailing" secondItem="lPU-cw-qqE" secondAttribute="trailing" id="uFv-Pj-4ll"/>
@@ -486,8 +468,7 @@
                 <outlet property="pswdConfirmTextFieldAndButtonViewOutlet" destination="F6s-RQ-22R" id="v0v-2q-Z26"/>
                 <outlet property="pswdConfirmValidationMessageLabelOutlet" destination="eY2-b6-On0" id="5tI-wo-a38"/>
                 <outlet property="signUpButtonOutlet" destination="YZp-rK-32z" id="2jr-Vi-Rtp"/>
-                <outlet property="termsAndServicesButtonOutlet" destination="JuJ-8k-i6o" id="gyu-mz-cvR"/>
-                <outlet property="termsAndServicesLabelOutlet" destination="ysg-6j-g6B" id="oLn-i1-MxY"/>
+                <outlet property="termsAndServicesTextViewOutlet" destination="mcI-Oe-1fg" id="HaC-8s-Dqn"/>
                 <outlet property="titleLabelOutlet" destination="Dtd-MK-bQ0" id="v4q-H7-B6l"/>
                 <outlet property="usernameErrorsView" destination="uRL-5A-Qkd" id="8Ul-M3-gpo"/>
                 <outlet property="usernameHeightConstraint" destination="V1c-OA-D28" id="dID-Dp-6ec"/>

--- a/Authentication/SignUp/View/SignupView.xib
+++ b/Authentication/SignUp/View/SignupView.xib
@@ -29,13 +29,85 @@
                     </constraints>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pSa-0q-elf" userLabel="Textfields View">
-                    <rect key="frame" x="0.0" y="81" width="418" height="136"/>
+                    <rect key="frame" x="0.0" y="81" width="418" height="282"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="1m5-f7-Ni1" userLabel="Outer Stack View">
-                            <rect key="frame" x="0.0" y="0.0" width="418" height="136"/>
+                            <rect key="frame" x="0.0" y="0.0" width="418" height="282"/>
                             <subviews>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Z1A-j1-8cE" userLabel="Email View">
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cF3-Hf-HdQ" userLabel="Username View">
                                     <rect key="frame" x="0.0" y="0.0" width="418" height="63"/>
+                                    <subviews>
+                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="Se8-br-qEr">
+                                            <rect key="frame" x="21" y="0.0" width="376" height="63"/>
+                                            <subviews>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ivD-JH-NwC" userLabel="Username TextField">
+                                                    <rect key="frame" x="0.0" y="0.0" width="376" height="43"/>
+                                                    <subviews>
+                                                        <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="XvZ-aF-I3u">
+                                                            <rect key="frame" x="8" y="0.0" width="360" height="43"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                            <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="emailAddress" returnKeyType="next"/>
+                                                        </textField>
+                                                    </subviews>
+                                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                    <constraints>
+                                                        <constraint firstItem="XvZ-aF-I3u" firstAttribute="leading" secondItem="ivD-JH-NwC" secondAttribute="leading" constant="8" id="4CS-wf-lRd"/>
+                                                        <constraint firstItem="XvZ-aF-I3u" firstAttribute="top" secondItem="ivD-JH-NwC" secondAttribute="top" id="U8b-3t-46h"/>
+                                                        <constraint firstAttribute="height" constant="43" id="cHj-Ut-Cp6"/>
+                                                        <constraint firstAttribute="bottom" secondItem="XvZ-aF-I3u" secondAttribute="bottom" id="mur-XK-oiF"/>
+                                                        <constraint firstAttribute="trailing" secondItem="XvZ-aF-I3u" secondAttribute="trailing" constant="8" id="wWK-oS-6wu"/>
+                                                    </constraints>
+                                                    <variation key="default">
+                                                        <mask key="constraints">
+                                                            <exclude reference="cHj-Ut-Cp6"/>
+                                                        </mask>
+                                                    </variation>
+                                                </view>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uRL-5A-Qkd" userLabel="Errors View">
+                                                    <rect key="frame" x="0.0" y="48" width="376" height="15"/>
+                                                    <subviews>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Username errors" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yOk-lO-oPb" userLabel="Username errors">
+                                                            <rect key="frame" x="281" y="0.0" width="95" height="15"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                            <color key="textColor" red="0.87805986400000002" green="0.0" blue="0.061996804019999997" alpha="1" colorSpace="calibratedRGB"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                    </subviews>
+                                                    <constraints>
+                                                        <constraint firstItem="yOk-lO-oPb" firstAttribute="top" secondItem="uRL-5A-Qkd" secondAttribute="top" id="6FR-6u-pxu"/>
+                                                        <constraint firstItem="yOk-lO-oPb" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="uRL-5A-Qkd" secondAttribute="leading" id="f76-0y-PDg"/>
+                                                        <constraint firstAttribute="trailing" secondItem="yOk-lO-oPb" secondAttribute="trailing" id="nrS-Id-Ox0"/>
+                                                        <constraint firstAttribute="bottom" secondItem="yOk-lO-oPb" secondAttribute="bottom" id="xYK-Gr-SKy"/>
+                                                    </constraints>
+                                                </view>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="ivD-JH-NwC" firstAttribute="width" secondItem="Se8-br-qEr" secondAttribute="width" id="dxN-rO-SWN"/>
+                                                <constraint firstItem="uRL-5A-Qkd" firstAttribute="width" secondItem="ivD-JH-NwC" secondAttribute="width" id="pGp-IU-uK1"/>
+                                                <constraint firstAttribute="bottom" secondItem="uRL-5A-Qkd" secondAttribute="bottom" id="zvX-sg-UeD"/>
+                                            </constraints>
+                                            <variation key="default">
+                                                <mask key="constraints">
+                                                    <exclude reference="zvX-sg-UeD"/>
+                                                </mask>
+                                            </variation>
+                                        </stackView>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstItem="Se8-br-qEr" firstAttribute="leading" secondItem="cF3-Hf-HdQ" secondAttribute="leading" constant="21" id="4o4-77-gqq"/>
+                                        <constraint firstAttribute="bottom" secondItem="Se8-br-qEr" secondAttribute="bottom" id="hOm-4W-5Bx"/>
+                                        <constraint firstItem="Se8-br-qEr" firstAttribute="top" secondItem="cF3-Hf-HdQ" secondAttribute="top" id="nOi-ue-ecm"/>
+                                        <constraint firstAttribute="trailing" secondItem="Se8-br-qEr" secondAttribute="trailing" constant="21" id="viJ-OK-ie5"/>
+                                    </constraints>
+                                    <variation key="default">
+                                        <mask key="constraints">
+                                            <exclude reference="viJ-OK-ie5"/>
+                                            <exclude reference="4o4-77-gqq"/>
+                                        </mask>
+                                    </variation>
+                                </view>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Z1A-j1-8cE" userLabel="Email View">
+                                    <rect key="frame" x="0.0" y="73" width="418" height="63"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="OcG-29-7E9">
                                             <rect key="frame" x="21" y="0.0" width="376" height="63"/>
@@ -72,6 +144,7 @@
                                                         <constraint firstItem="qlr-5N-r0b" firstAttribute="top" secondItem="RQ6-LA-hWA" secondAttribute="top" id="Jd1-Qy-xek"/>
                                                         <constraint firstAttribute="trailing" secondItem="qlr-5N-r0b" secondAttribute="trailing" id="Q7s-IF-9JL"/>
                                                         <constraint firstAttribute="bottom" secondItem="qlr-5N-r0b" secondAttribute="bottom" id="WQi-Vk-bKz"/>
+                                                        <constraint firstItem="qlr-5N-r0b" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="RQ6-LA-hWA" secondAttribute="leading" id="oDO-sE-6bw"/>
                                                     </constraints>
                                                 </view>
                                             </subviews>
@@ -95,7 +168,7 @@
                                     </constraints>
                                 </view>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1Tn-q6-mhF" userLabel="Password View">
-                                    <rect key="frame" x="0.0" y="73" width="418" height="63"/>
+                                    <rect key="frame" x="0.0" y="146" width="418" height="63"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="bdX-sZ-h5E">
                                             <rect key="frame" x="21" y="0.0" width="376" height="63"/>
@@ -103,18 +176,18 @@
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JVi-Ec-hKI" userLabel="Password TextField">
                                                     <rect key="frame" x="0.0" y="0.0" width="376" height="43"/>
                                                     <subviews>
-                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="f0R-Cq-Zz3">
-                                                            <rect key="frame" x="331" y="0.0" width="45" height="43"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="width" constant="45" id="51q-uO-k85"/>
-                                                            </constraints>
-                                                            <state key="normal" title="Ver"/>
-                                                        </button>
                                                         <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="88a-FE-Vb2">
                                                             <rect key="frame" x="8" y="0.0" width="323" height="43"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                            <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="go" secureTextEntry="YES"/>
+                                                            <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="next" secureTextEntry="YES"/>
                                                         </textField>
+                                                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="f0R-Cq-Zz3">
+                                                            <rect key="frame" x="331" y="0.0" width="45" height="43"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="45" id="51q-uO-k85"/>
+                                                            </constraints>
+                                                            <state key="normal" title="Ver"/>
+                                                        </button>
                                                     </subviews>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                     <constraints>
@@ -138,6 +211,7 @@
                                                         </label>
                                                     </subviews>
                                                     <constraints>
+                                                        <constraint firstItem="gkr-sO-rLU" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="H8J-KY-Ia1" secondAttribute="leading" id="NNs-ao-fSa"/>
                                                         <constraint firstAttribute="bottom" secondItem="gkr-sO-rLU" secondAttribute="bottom" id="Ocj-39-EDV"/>
                                                         <constraint firstAttribute="trailing" secondItem="gkr-sO-rLU" secondAttribute="trailing" id="XaJ-W6-SkP"/>
                                                         <constraint firstItem="gkr-sO-rLU" firstAttribute="top" secondItem="H8J-KY-Ia1" secondAttribute="top" id="mdW-gp-bMf"/>
@@ -163,20 +237,92 @@
                                         </mask>
                                     </variation>
                                 </view>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SmF-k6-eer" userLabel="Confirm Password View">
+                                    <rect key="frame" x="0.0" y="219" width="418" height="63"/>
+                                    <subviews>
+                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="Ql6-XT-wS4">
+                                            <rect key="frame" x="21" y="0.0" width="376" height="63"/>
+                                            <subviews>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="F6s-RQ-22R" userLabel="Confirm Password TextField">
+                                                    <rect key="frame" x="0.0" y="0.0" width="376" height="43"/>
+                                                    <subviews>
+                                                        <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="aTp-Hh-88z">
+                                                            <rect key="frame" x="8" y="0.0" width="323" height="43"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                            <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="go" secureTextEntry="YES"/>
+                                                        </textField>
+                                                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yXM-l0-Y9w">
+                                                            <rect key="frame" x="331" y="0.0" width="45" height="43"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="45" id="AHH-7d-OGN"/>
+                                                            </constraints>
+                                                            <state key="normal" title="Ver"/>
+                                                        </button>
+                                                    </subviews>
+                                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                    <constraints>
+                                                        <constraint firstItem="aTp-Hh-88z" firstAttribute="top" secondItem="F6s-RQ-22R" secondAttribute="top" id="0qg-nX-ZYP"/>
+                                                        <constraint firstAttribute="bottom" secondItem="yXM-l0-Y9w" secondAttribute="bottom" id="GQU-r9-T6c"/>
+                                                        <constraint firstItem="aTp-Hh-88z" firstAttribute="leading" secondItem="F6s-RQ-22R" secondAttribute="leading" constant="8" id="JId-HT-8rm"/>
+                                                        <constraint firstAttribute="bottom" secondItem="aTp-Hh-88z" secondAttribute="bottom" id="W5Q-bJ-nXk"/>
+                                                        <constraint firstItem="yXM-l0-Y9w" firstAttribute="top" secondItem="F6s-RQ-22R" secondAttribute="top" id="YfH-dz-l0D"/>
+                                                        <constraint firstItem="yXM-l0-Y9w" firstAttribute="leading" secondItem="aTp-Hh-88z" secondAttribute="trailing" id="rWK-2b-MHi"/>
+                                                        <constraint firstAttribute="trailing" secondItem="yXM-l0-Y9w" secondAttribute="trailing" id="y1U-vV-g0j"/>
+                                                    </constraints>
+                                                </view>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pkS-sb-sDR" userLabel="Errors View">
+                                                    <rect key="frame" x="0.0" y="48" width="376" height="15"/>
+                                                    <subviews>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Confirm Password errors" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eY2-b6-On0" userLabel="Confirm Password errors">
+                                                            <rect key="frame" x="236" y="0.0" width="140" height="15"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                            <color key="textColor" red="0.87805986400000002" green="0.0" blue="0.061996804019999997" alpha="1" colorSpace="calibratedRGB"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                    </subviews>
+                                                    <constraints>
+                                                        <constraint firstItem="eY2-b6-On0" firstAttribute="top" secondItem="pkS-sb-sDR" secondAttribute="top" id="TRs-P8-HHW"/>
+                                                        <constraint firstItem="eY2-b6-On0" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="pkS-sb-sDR" secondAttribute="leading" id="oR5-8U-FYm"/>
+                                                        <constraint firstAttribute="bottom" secondItem="eY2-b6-On0" secondAttribute="bottom" id="vKi-nL-9gh"/>
+                                                        <constraint firstAttribute="trailing" secondItem="eY2-b6-On0" secondAttribute="trailing" id="zyM-bz-gv5"/>
+                                                    </constraints>
+                                                </view>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="F6s-RQ-22R" firstAttribute="width" secondItem="Ql6-XT-wS4" secondAttribute="width" id="B4H-oz-PqC"/>
+                                                <constraint firstItem="pkS-sb-sDR" firstAttribute="width" secondItem="F6s-RQ-22R" secondAttribute="width" id="OMo-mz-yeU"/>
+                                            </constraints>
+                                        </stackView>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstItem="Ql6-XT-wS4" firstAttribute="top" secondItem="SmF-k6-eer" secondAttribute="top" id="38c-ah-Z04"/>
+                                        <constraint firstAttribute="trailing" secondItem="Ql6-XT-wS4" secondAttribute="trailing" constant="21" id="A84-d5-APp"/>
+                                        <constraint firstAttribute="bottom" secondItem="Ql6-XT-wS4" secondAttribute="bottom" id="ei4-oa-llV"/>
+                                        <constraint firstItem="Ql6-XT-wS4" firstAttribute="leading" secondItem="SmF-k6-eer" secondAttribute="leading" constant="21" id="roL-dD-6hO"/>
+                                    </constraints>
+                                    <variation key="default">
+                                        <mask key="constraints">
+                                            <exclude reference="A84-d5-APp"/>
+                                            <exclude reference="roL-dD-6hO"/>
+                                        </mask>
+                                    </variation>
+                                </view>
                             </subviews>
                             <constraints>
-                                <constraint firstItem="1Tn-q6-mhF" firstAttribute="width" secondItem="1m5-f7-Ni1" secondAttribute="width" id="A5x-ML-v9c"/>
+                                <constraint firstItem="SmF-k6-eer" firstAttribute="width" secondItem="Z1A-j1-8cE" secondAttribute="width" id="6f1-2z-303"/>
+                                <constraint firstItem="cF3-Hf-HdQ" firstAttribute="width" secondItem="Z1A-j1-8cE" secondAttribute="width" id="J5f-gz-GFG"/>
                                 <constraint firstItem="Z1A-j1-8cE" firstAttribute="width" secondItem="1m5-f7-Ni1" secondAttribute="width" id="Lwx-oz-Nh0"/>
+                                <constraint firstItem="ivD-JH-NwC" firstAttribute="height" secondItem="wS1-Yg-TTU" secondAttribute="height" id="V1c-OA-D28"/>
                                 <constraint firstItem="bdX-sZ-h5E" firstAttribute="trailing" secondItem="OcG-29-7E9" secondAttribute="trailing" id="c0e-Yw-HHB"/>
+                                <constraint firstItem="F6s-RQ-22R" firstAttribute="height" secondItem="wS1-Yg-TTU" secondAttribute="height" id="dnz-rb-Ied"/>
                                 <constraint firstItem="bdX-sZ-h5E" firstAttribute="leading" secondItem="OcG-29-7E9" secondAttribute="leading" id="gxJ-ze-Qbs"/>
                                 <constraint firstItem="1Tn-q6-mhF" firstAttribute="width" secondItem="Z1A-j1-8cE" secondAttribute="width" id="iaI-rD-7dg"/>
+                                <constraint firstItem="Ql6-XT-wS4" firstAttribute="trailing" secondItem="OcG-29-7E9" secondAttribute="trailing" id="lcP-XB-yiO"/>
+                                <constraint firstItem="Ql6-XT-wS4" firstAttribute="leading" secondItem="OcG-29-7E9" secondAttribute="leading" id="ln3-7P-RUP"/>
+                                <constraint firstItem="Se8-br-qEr" firstAttribute="leading" secondItem="OcG-29-7E9" secondAttribute="leading" id="pY8-i5-rjc"/>
                                 <constraint firstItem="JVi-Ec-hKI" firstAttribute="height" secondItem="wS1-Yg-TTU" secondAttribute="height" id="qOT-pG-qj4"/>
+                                <constraint firstItem="Se8-br-qEr" firstAttribute="trailing" secondItem="OcG-29-7E9" secondAttribute="trailing" id="sPe-u8-W5N"/>
                             </constraints>
-                            <variation key="default">
-                                <mask key="constraints">
-                                    <exclude reference="A5x-ML-v9c"/>
-                                </mask>
-                            </variation>
                         </stackView>
                     </subviews>
                     <constraints>
@@ -187,7 +333,7 @@
                     </constraints>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Iqv-fj-4Xd" userLabel="SignUp View">
-                    <rect key="frame" x="0.0" y="217" width="418" height="390"/>
+                    <rect key="frame" x="0.0" y="363" width="418" height="244"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="X8o-uo-260" userLabel="Terms&amp;Serivces View">
                             <rect key="frame" x="0.0" y="0.0" width="418" height="82"/>
@@ -234,7 +380,7 @@
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6RS-Mz-klY" userLabel="Button View">
-                            <rect key="frame" x="0.0" y="82" width="418" height="249"/>
+                            <rect key="frame" x="0.0" y="82" width="418" height="103"/>
                             <subviews>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YZp-rK-32z">
                                     <rect key="frame" x="21" y="0.0" width="376" height="50"/>
@@ -258,7 +404,7 @@
                             </variation>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TH1-Y1-ZZn" userLabel="Log In View">
-                            <rect key="frame" x="0.0" y="331" width="418" height="59"/>
+                            <rect key="frame" x="0.0" y="185" width="418" height="59"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="¿Ya estás registrado?" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Rl4-RA-UdB">
                                     <rect key="frame" x="140" y="0.0" width="138" height="17"/>
@@ -327,15 +473,28 @@
                 <outlet property="emailValidationMessageLabelOutlet" destination="qlr-5N-r0b" id="4SM-hA-7U9"/>
                 <outlet property="loginButtonOutlet" destination="h1l-gv-6Fh" id="7i8-jd-cRv"/>
                 <outlet property="loginLabelOutlet" destination="Rl4-RA-UdB" id="hmE-C3-FxU"/>
+                <outlet property="passwordConfirmTextFieldOutlet" destination="aTp-Hh-88z" id="M64-bB-Fgs"/>
+                <outlet property="passwordConfirmVisibilityButtonOutlet" destination="yXM-l0-Y9w" id="fNL-Zy-AAw"/>
+                <outlet property="passwordConfirmationErrorsView" destination="pkS-sb-sDR" id="GzD-Xa-4Xl"/>
+                <outlet property="passwordConfirmationHeightConstraint" destination="dnz-rb-Ied" id="SAG-up-8mE"/>
+                <outlet property="passwordConfirmationView" destination="SmF-k6-eer" id="oQf-JE-mn8"/>
                 <outlet property="passwordErrorsView" destination="H8J-KY-Ia1" id="em5-T1-cgS"/>
                 <outlet property="passwordTextFieldAndButtonViewOutlet" destination="JVi-Ec-hKI" id="Y6T-xL-Mak"/>
                 <outlet property="passwordTextFieldOutlet" destination="88a-FE-Vb2" id="6Kj-Ay-xmh"/>
                 <outlet property="passwordValidationMessageLabelOutlet" destination="gkr-sO-rLU" id="tUM-6F-QQO"/>
                 <outlet property="passwordVisibilityButtonOutlet" destination="f0R-Cq-Zz3" id="61Q-cC-fGh"/>
+                <outlet property="pswdConfirmTextFieldAndButtonViewOutlet" destination="F6s-RQ-22R" id="v0v-2q-Z26"/>
+                <outlet property="pswdConfirmValidationMessageLabelOutlet" destination="eY2-b6-On0" id="5tI-wo-a38"/>
                 <outlet property="signUpButtonOutlet" destination="YZp-rK-32z" id="2jr-Vi-Rtp"/>
                 <outlet property="termsAndServicesButtonOutlet" destination="JuJ-8k-i6o" id="gyu-mz-cvR"/>
                 <outlet property="termsAndServicesLabelOutlet" destination="ysg-6j-g6B" id="oLn-i1-MxY"/>
                 <outlet property="titleLabelOutlet" destination="Dtd-MK-bQ0" id="v4q-H7-B6l"/>
+                <outlet property="usernameErrorsView" destination="uRL-5A-Qkd" id="8Ul-M3-gpo"/>
+                <outlet property="usernameHeightConstraint" destination="V1c-OA-D28" id="dID-Dp-6ec"/>
+                <outlet property="usernameTextFieldOutlet" destination="XvZ-aF-I3u" id="nTj-AT-duR"/>
+                <outlet property="usernameTextFieldViewOutlet" destination="ivD-JH-NwC" id="upo-KG-Poy"/>
+                <outlet property="usernameValidationMessageLabelOutlet" destination="yOk-lO-oPb" id="EqJ-iM-H1j"/>
+                <outlet property="usernameView" destination="cF3-Hf-HdQ" id="sMK-m1-nQr"/>
             </connections>
             <point key="canvasLocation" x="225" y="469.5"/>
         </view>

--- a/Authentication/SignUp/View/SignupViewConfiguration.swift
+++ b/Authentication/SignUp/View/SignupViewConfiguration.swift
@@ -6,30 +6,46 @@
 //  Copyright © 2016 Wolox. All rights reserved.
 //
 
-import Foundation
 
+/*
+     Represents the configurations able to
+     be customized to a SignupViewType.
+     Includes the font and color palettes,
+     and the decision to include or exclude
+     optional textfields.
+ */
 public protocol SignupViewConfigurationType {
     
     var colorPalette: ColorPaletteType { get }
     var fontPalette: FontPaletteType { get }
-    // Must be consistent with the view used.
+    
+    // Textfield selected must be consistent with the view used.
     var usernameEnabled: Bool { get }
     var passwordConfirmationEnabled: Bool { get }
     
 }
 
-public struct DefaultSignupViewConfiguration: SignupViewConfigurationType {
+/*
+    The SignupViewConfiguration stores all palettes
+    and decisions necessary.
+    By default, it uses the default palettes and
+    doesn't include optional textfields.
+ */
+public struct SignupViewConfiguration: SignupViewConfigurationType {
     
     public let colorPalette: ColorPaletteType
     public let fontPalette: FontPaletteType
     public let usernameEnabled: Bool
     public let passwordConfirmationEnabled: Bool
     
-    public init() {
-        colorPalette = DefaultColorPalette()
-        fontPalette = DefaultFontPalette()
-        usernameEnabled = false
-        passwordConfirmationEnabled = false
+    public init(colorPalette: ColorPaletteType = DefaultColorPalette(),
+                fontPalette: FontPaletteType = DefaultFontPalette(),
+                usernameEnabled: Bool = false,
+                passwordConfirmationEnabled: Bool = false) {
+        self.colorPalette = colorPalette
+        self.fontPalette = fontPalette
+        self.usernameEnabled = usernameEnabled
+        self.passwordConfirmationEnabled = passwordConfirmationEnabled
     }
     
 }

--- a/Authentication/SignUp/View/SignupViewDelegate.swift
+++ b/Authentication/SignUp/View/SignupViewDelegate.swift
@@ -87,6 +87,11 @@ public final class DefaultSignupViewDelegate: SignupViewDelegate {
         signupView.termsAndServicesLabel?.textColor = colorPalette.labels
         signupView.termsAndServicesButton.titleLabel?.font = fontPalette.links
         signupView.termsAndServicesButton.titleLabel?.textColor = colorPalette.links
+        
+        signupView.loginLabel?.font = fontPalette.labels
+        signupView.loginLabel?.textColor = colorPalette.labels
+        signupView.loginButton.titleLabel?.font = fontPalette.links
+        signupView.loginButton.titleLabel?.textColor = colorPalette.links
     }
     
     private func configureErrorElements(signupView: SignupViewType) {

--- a/Authentication/SignUp/View/SignupViewDelegate.swift
+++ b/Authentication/SignUp/View/SignupViewDelegate.swift
@@ -6,29 +6,44 @@
 //  Copyright © 2016 Wolox. All rights reserved.
 //
 
-import Foundation
-
+/*
+     Delegate for any extra configuration
+     to the signup view when rendered.
+ */
 public protocol SignupViewDelegate {
     
+    /* Palettes ued to configure all login view elements possible. */
     var colorPalette: ColorPaletteType { get }
     var fontPalette: FontPaletteType { get }
     
+    /* Function to configure all view elements according to the palettes.
+       It is called by the default signup view when rendered. */
     func configureView(signupView: SignupViewType)
     
 }
 
 public extension SignupViewDelegate {
     
+    /* By default, does nothing. */
     func configureView(signupView: SignupViewType) { }
     
 }
 
+/*
+     The default signup view delegate takes care of
+     setting all SignupViewType elements possible according to palettes.
+ 
+     If wanting to use the DefaultSignupViewDelegate with some palette customization,
+     you should not override the `createSignupViewDelegate` method of the Bootstrapper,
+     but pass the correct SignupViewConfigurationType to the bootstraper in the
+     `AuthenticationViewConfiguration`.
+ */
 public final class DefaultSignupViewDelegate: SignupViewDelegate {
     
     public let colorPalette: ColorPaletteType
     public let fontPalette: FontPaletteType
     
-    public init(configuration: SignupViewConfigurationType = DefaultSignupViewConfiguration()) {
+    internal init(configuration: SignupViewConfigurationType = DefaultSignupViewConfiguration()) {
         colorPalette = configuration.colorPalette
         fontPalette = configuration.fontPalette
     }

--- a/Authentication/SignUp/View/SignupViewDelegate.swift
+++ b/Authentication/SignUp/View/SignupViewDelegate.swift
@@ -43,7 +43,7 @@ public final class DefaultSignupViewDelegate: SignupViewDelegate {
     public let colorPalette: ColorPaletteType
     public let fontPalette: FontPaletteType
     
-    internal init(configuration: SignupViewConfigurationType = DefaultSignupViewConfiguration()) {
+    internal init(configuration: SignupViewConfigurationType = SignupViewConfiguration()) {
         colorPalette = configuration.colorPalette
         fontPalette = configuration.fontPalette
     }

--- a/Authentication/SignUp/View/SignupViewDelegate.swift
+++ b/Authentication/SignUp/View/SignupViewDelegate.swift
@@ -98,10 +98,8 @@ public final class DefaultSignupViewDelegate: SignupViewDelegate {
     }
     
     private func configureLinksElements(signupView: SignupViewType) {
-        signupView.termsAndServicesLabel?.font = fontPalette.labels
-        signupView.termsAndServicesLabel?.textColor = colorPalette.labels
-        signupView.termsAndServicesButton.titleLabel?.font = fontPalette.links
-        signupView.termsAndServicesButton.titleLabel?.textColor = colorPalette.links
+        signupView.termsAndServicesTextView.textColor = colorPalette.labels
+        signupView.termsAndServicesTextView.font = fontPalette.labels
         
         signupView.loginLabel?.font = fontPalette.labels
         signupView.loginLabel?.textColor = colorPalette.labels

--- a/Authentication/SignUp/ViewModel/SignupCredentialsValidator.swift
+++ b/Authentication/SignUp/ViewModel/SignupCredentialsValidator.swift
@@ -6,6 +6,11 @@
 //  Copyright © 2016 Wolox. All rights reserved.
 //
 
+/*
+    Represents a validator for all signup fields:
+    name, email and password.
+    It provides default validators for each of them.
+*/
 public struct SignupCredentialsValidator {
     
     public static func defaultNameValidator() -> TextInputValidatorType {
@@ -16,7 +21,7 @@ public struct SignupCredentialsValidator {
         return  CompositeTextInputValidator(validators: [
             NonEmptyValidator(),
             EmailValidator()
-            ])
+        ])
     }
     
     public static func defaultPasswordValidator(minLength: Int = 4, maxLength: Int? = 30) -> TextInputValidatorType {

--- a/Authentication/SignUp/ViewModel/SignupViewModel.swift
+++ b/Authentication/SignUp/ViewModel/SignupViewModel.swift
@@ -11,31 +11,48 @@ import ReactiveCocoa
 import enum Result.NoError
 import Rex
 
-
+/*
+     Protocol for signup view models.
+     They must handle validation and
+     actions of all possible signup elements.
+ */
 public protocol SignupViewModelType {
     
+    /* Name/Username field considerations: content and validation errors. */
     var name: MutableProperty<String> { get }
     var nameValidationErrors: AnyProperty<[String]> { get }
     
+    /* Email field considerations: content and validation errors. */
     var email: MutableProperty<String> { get }
     var emailValidationErrors: AnyProperty<[String]> { get }
     
+    /* Password field considerations: content, validation errors
+     and password visibility. */
     var password: MutableProperty<String> { get }
     var passwordValidationErrors: AnyProperty<[String]> { get }
     var passwordVisible: MutableProperty<Bool> { get }
     var togglePasswordVisibility: CocoaAction { get }
     
+    /* Confirm Password field considerations: content, validation
+     errors and password visibility. */
     var passwordConfirmation: MutableProperty<String> { get }
     var passwordConfirmationValidationErrors: AnyProperty<[String]> { get }
     var confirmationPasswordVisible: MutableProperty<Bool> { get }
     var toggleConfirmPasswordVisibility: CocoaAction { get }
     
+    /* Sign Up action considerations: action, executing state and errors. */
     var signUpCocoaAction: CocoaAction { get }
     var signUpErrors: Signal<SessionServiceError, NoError> { get }
     var signUpExecuting: Signal<Bool, NoError> { get }
     
 }
 
+/*
+     Default SignupViewModel responsible for validating entries to email and password fields
+     and username and/or password confirmation fields if required. Therefore it's also 
+     responsible for enabling sign up action, managing password visibility, reporting sign up
+     events and communicating with the session service for executing the sign up.
+ */
 public final class SignupViewModel<User: UserType, SessionService: SessionServiceType where SessionService.User == User>: SignupViewModelType {
     
     private let _sessionService: SessionService
@@ -67,10 +84,28 @@ public final class SignupViewModel<User: UserType, SessionService: SessionServic
     private lazy var _togglePasswordVisibility: Action<AnyObject, Bool, NoError> = self.initializeTogglePasswordVisibilityAction()
     private lazy var _toggleConfirmationPasswordVisibility: Action<AnyObject, Bool, NoError> = self.initializeToggleConfirmationPasswordVisibilityAction()
     
+    /*
+         Initializes a signup view model which will communicate to the session service provided and
+         will regulate the sign up with the validation criteria from the login credentials validator.
+         
+         - Parameters:
+             - sessionService: session service to communicate with for sign up action.
+             - credentialsValidator: signup credentials validator which encapsulates the criteria
+             that the email, password and username fields must meet.
+             - usernameEnabled: property indicating if this view model should take into account
+             username validation.
+             - passwordConfirmationEnabled: property indicating if this view model should take
+             into account the password confirmation validation.
+     
+         - Warning: The `usernameEnabled` and `passwordConfirmationEnabled` properties should be
+         consistent with the view that will be used.
+     
+         - Returns: A valid signup view model ready to use.
+     */
     internal init(sessionService: SessionService,
-         credentialsValidator: SignupCredentialsValidator = SignupCredentialsValidator(),
-         passwordConfirmationEnabled: Bool = true,
-         usernameEnabled: Bool = true) {
+                  credentialsValidator: SignupCredentialsValidator = SignupCredentialsValidator(),
+                  usernameEnabled: Bool = true,
+                  passwordConfirmationEnabled: Bool = true) {
         _sessionService = sessionService
         
         let nameValidationResult = name.signal.map(credentialsValidator.nameValidator.validate)

--- a/Authentication/SignUp/ViewModel/SignupViewModel.swift
+++ b/Authentication/SignUp/ViewModel/SignupViewModel.swift
@@ -146,8 +146,10 @@ private extension SignupViewModel {
     private func initializeSignUpAction() -> Action<AnyObject, User, SessionServiceError> {
         return Action(enabledIf: self._credentialsAreValid) { [unowned self] _ in
             if let email = Email(raw: self.email.value) {
-                return self._sessionService.signUp(self.name.value, email: email, password: self.password.value)
+                let name: String? = self.usernameEnabled ? self.name.value : .None
+                return self._sessionService.signUp(name, email: email, password: self.password.value)
             } else {
+                // It will never enter here, since sign up action is only enabled when email is a valid email.
                 return SignalProducer(error: .InvalidSignUpCredentials(.None)).observeOn(UIScheduler())
             }
         }

--- a/Authentication/SignUp/ViewModel/SignupViewModel.swift
+++ b/Authentication/SignUp/ViewModel/SignupViewModel.swift
@@ -45,6 +45,9 @@ public protocol SignupViewModelType {
     var signUpErrors: Signal<SessionServiceError, NoError> { get }
     var signUpExecuting: Signal<Bool, NoError> { get }
     
+    var usernameEnabled: Bool { get }
+    var passwordConfirmationEnabled: Bool { get }
+    
 }
 
 /*
@@ -54,10 +57,6 @@ public protocol SignupViewModelType {
      events and communicating with the session service for executing the sign up.
  */
 public final class SignupViewModel<User: UserType, SessionService: SessionServiceType where SessionService.User == User>: SignupViewModelType {
-    
-    private let _sessionService: SessionService
-    
-    private let _credentialsAreValid: AndProperty
     
     public let name = MutableProperty("")
     public let email = MutableProperty("")
@@ -78,6 +77,12 @@ public final class SignupViewModel<User: UserType, SessionService: SessionServic
     
     public var togglePasswordVisibility: CocoaAction { return _togglePasswordVisibility.unsafeCocoaAction }
     public var toggleConfirmPasswordVisibility: CocoaAction { return _toggleConfirmationPasswordVisibility.unsafeCocoaAction }
+    
+    public let usernameEnabled: Bool
+    public let passwordConfirmationEnabled: Bool
+    
+    private let _sessionService: SessionService
+    private let _credentialsAreValid: AndProperty
     
     private lazy var _signUp: Action<AnyObject, User, SessionServiceError> = self.initializeSignUpAction()
     
@@ -130,6 +135,8 @@ public final class SignupViewModel<User: UserType, SessionService: SessionServic
                 .and(AnyProperty<Bool>(initialValue: false, signal:passwordConfirmValidationResult.map { $0.isValid }))
         }
         _credentialsAreValid = credentialsAreValid
+        self.usernameEnabled = usernameEnabled
+        self.passwordConfirmationEnabled = passwordConfirmationEnabled
     }
     
 }

--- a/Authentication/Supporting Files/Base.lproj/Localizable.strings
+++ b/Authentication/Supporting Files/Base.lproj/Localizable.strings
@@ -45,8 +45,9 @@
 "signup-view.email-placeholder" = "Email";
 "signup-view.password-placeholder" = "Password";
 "signup-view.confirm-password-placeholder" = "Confirm password";
-"signup-view.terms-and-services.label-text" = "By signing up, I agree to the";
-"signup-view.terms-and-services.button-title" = "Terms and Services";
+"signup-view.terms-and-services.text" = "By signing up, I agree to the Terms and Services";
+"signup-view.terms-and-services.link-text" = "Terms and Services";
+"signup-view.terms-and-services.link-url" = "";
 "signup-view.signup-button-title" = "SIGN UP";
 "signup-view.login.label-text" = "Already registered?";
 "signup-view.login.button-title" = "Log In";

--- a/Authentication/Supporting Files/Base.lproj/Localizable.strings
+++ b/Authentication/Supporting Files/Base.lproj/Localizable.strings
@@ -45,7 +45,7 @@
 "signup-view.email-placeholder" = "Email";
 "signup-view.password-placeholder" = "Password";
 "signup-view.confirm-password-placeholder" = "Confirm password";
-"signup-view.terms-and-services.text" = "By signing up, I agree to the Terms and Services.";
+"signup-view.terms-and-services.text" = "By signing up I agree to the Terms and Services.";
 "signup-view.terms-and-services.link-text" = "Terms and Services";
 "signup-view.terms-and-services.link-url" = "";
 "signup-view.signup-button-title" = "SIGN UP";

--- a/Authentication/Supporting Files/Base.lproj/Localizable.strings
+++ b/Authentication/Supporting Files/Base.lproj/Localizable.strings
@@ -22,9 +22,9 @@
 "login-view.email-placeholder" = "Email";
 "login-view.password-placeholder" = "Password";
 "login-view.login-button-title" = "LOG IN";
-"login-view.signup-button-title" = "Sign up";
 "login-view.recover-password-button-title" = "Forgot password?";
 "login-view.to-signup-label" = "Don't have an account?";
+"login-view.signup-button-title" = "Sign up";
 
 /* Session service errors */
 "login-error.invalid-credentials.message" = "Wrong email or password";
@@ -45,11 +45,11 @@
 "signup-view.email-placeholder" = "Email";
 "signup-view.password-placeholder" = "Password";
 "signup-view.confirm-password-placeholder" = "Confirm password";
-"signup-view.terms-and-services.text" = "By signing up, I agree to the Terms and Services";
+"signup-view.terms-and-services.text" = "By signing up, I agree to the Terms and Services.";
 "signup-view.terms-and-services.link-text" = "Terms and Services";
 "signup-view.terms-and-services.link-url" = "";
 "signup-view.signup-button-title" = "SIGN UP";
-"signup-view.login.label-text" = "Already registered?";
+"signup-view.login.label-text" = "Registered already?";
 "signup-view.login.button-title" = "Log In";
 
 /* Signup errors */

--- a/Authentication/Supporting Files/Base.lproj/Localizable.strings
+++ b/Authentication/Supporting Files/Base.lproj/Localizable.strings
@@ -27,9 +27,9 @@
 "login-view.to-signup-label" = "Don't have an account?";
 
 /* Session service errors */
-"login-error.invalid-credentials.message" = "Wrong email or password. ";
-"signup-error.invalid-credentials.message" = "Invalid credentials. ";
-"network-error.message" = "Network error. ";
+"login-error.invalid-credentials.message" = "Wrong email or password";
+"signup-error.invalid-credentials.message" = "Invalid credentials";
+"network-error.message" = "Network error";
 
 /* LogIn error alert */
 "login-error.alert.title" = "Unable to log in";

--- a/Authentication/Supporting Files/en.lproj/Localizable.strings
+++ b/Authentication/Supporting Files/en.lproj/Localizable.strings
@@ -45,8 +45,9 @@
 "signup-view.email-placeholder" = "Email";
 "signup-view.password-placeholder" = "Password";
 "signup-view.confirm-password-placeholder" = "Confirm password";
-"signup-view.terms-and-services.label-text" = "By signing up, I agree to the";
-"signup-view.terms-and-services.button-title" = "Terms and Services";
+"signup-view.terms-and-services.text" = "By signing up, I agree to the Terms and Services.";
+"signup-view.terms-and-services.link-text" = "Terms and Services";
+"signup-view.terms-and-services.link-url" = "";
 "signup-view.signup-button-title" = "SIGN UP";
 "signup-view.login.label-text" = "Already registered?";
 "signup-view.login.button-title" = "Log In";

--- a/Authentication/Supporting Files/en.lproj/Localizable.strings
+++ b/Authentication/Supporting Files/en.lproj/Localizable.strings
@@ -45,7 +45,7 @@
 "signup-view.email-placeholder" = "Email";
 "signup-view.password-placeholder" = "Password";
 "signup-view.confirm-password-placeholder" = "Confirm password";
-"signup-view.terms-and-services.text" = "By signing up, I agree to the Terms and Services.";
+"signup-view.terms-and-services.text" = "By signing up I agree to the Terms and Services.";
 "signup-view.terms-and-services.link-text" = "Terms and Services";
 "signup-view.terms-and-services.link-url" = "";
 "signup-view.signup-button-title" = "SIGN UP";

--- a/Authentication/Supporting Files/en.lproj/Localizable.strings
+++ b/Authentication/Supporting Files/en.lproj/Localizable.strings
@@ -22,9 +22,9 @@
 "login-view.email-placeholder" = "Email";
 "login-view.password-placeholder" = "Password";
 "login-view.login-button-title" = "LOG IN";
-"login-view.signup-button-title" = "Sign up";
 "login-view.recover-password-button-title" = "Forgot password?";
-"login-view.to-signup-label" = "Don't have an account?";
+"login-view.to-signup-label" = "Don't have an account?"; // New to X?
+"login-view.signup-button-title" = "Sign up";
 
 /* Session service errors */
 "login-error.invalid-credentials.message" = "Wrong email or password";
@@ -49,7 +49,7 @@
 "signup-view.terms-and-services.link-text" = "Terms and Services";
 "signup-view.terms-and-services.link-url" = "";
 "signup-view.signup-button-title" = "SIGN UP";
-"signup-view.login.label-text" = "Already registered?";
+"signup-view.login.label-text" = "Registered already?";
 "signup-view.login.button-title" = "Log In";
 
 /* Signup errors */

--- a/Authentication/Supporting Files/en.lproj/Localizable.strings
+++ b/Authentication/Supporting Files/en.lproj/Localizable.strings
@@ -27,9 +27,9 @@
 "login-view.to-signup-label" = "Don't have an account?";
 
 /* Session service errors */
-"login-error.invalid-credentials.message" = "Wrong email or password. ";
-"signup-error.invalid-credentials.message" = "Invalid credentials. ";
-"network-error.message" = "Network error. ";
+"login-error.invalid-credentials.message" = "Wrong email or password";
+"signup-error.invalid-credentials.message" = "Invalid credentials";
+"network-error.message" = "Network error";
 
 /* LogIn error alert */
 "login-error.alert.title" = "Unable to log in";

--- a/Authentication/Supporting Files/es.lproj/Spanish(es).strings
+++ b/Authentication/Supporting Files/es.lproj/Spanish(es).strings
@@ -27,9 +27,9 @@
 "login-view.to-signup-label" = "¿No tienes cuenta?";
 
 /* Errores del servicio de sesión */
-"login-error.invalid-credentials.message" = "Email o contraseña incorrectos. ";
-"signup-error.invalid-credentials.message" = "Credenciales incorrectas. ";
-"network-error.message" = "Error en la conexión. ";
+"login-error.invalid-credentials.message" = "Email o contraseña incorrectos";
+"signup-error.invalid-credentials.message" = "Credenciales incorrectas";
+"network-error.message" = "Error en la conexión";
 
 /* Alerta de error de login */
 "login-error.alert.title" = "Error al intentar ingresar";

--- a/Authentication/Supporting Files/es.lproj/Spanish(es).strings
+++ b/Authentication/Supporting Files/es.lproj/Spanish(es).strings
@@ -45,8 +45,9 @@
 "signup-view.email-placeholder" = "Email";
 "signup-view.password-placeholder" = "Contraseña";
 "signup-view.confirm-password-placeholder" = "Confirme contraseña";
-"signup-view.terms-and-services.label-text" = "Al registrarme, acepto los";
-"signup-view.terms-and-services.button-title" = "Términos y Servicios";
+"signup-view.terms-and-services.text" = "Al registrarme, acepto los Términos y Servicios.";
+"signup-view.terms-and-services.link-text" = "Términos y Servicios";
+"signup-view.terms-and-services.link-url" = "";
 "signup-view.signup-button-title" = "REGISTRARSE";
 "signup-view.login.label-text" = "¿Ya está registrado?";
 "signup-view.login.button-title" = "Inicie sesión";

--- a/Authentication/Supporting Files/es.lproj/Spanish(es).strings
+++ b/Authentication/Supporting Files/es.lproj/Spanish(es).strings
@@ -17,14 +17,14 @@
 "text-visibility-button-title.true" = "Mostrar";
 
 /* Títulos de los elementos de UI del login */
-"login-view-model.email" = "Email:";
-"login-view-model.password" = "Contraseña:";
-"login-view-model.email-placeholder" = "Email";
-"login-view-model.password-placeholder" = "Contraseña";
-"login-view-model.login-button-title" = "INGRESAR";
-"login-view-model.recover-password-button-title" = "Recuperar contraseña";
+"login-view.email" = "Email:";
+"login-view.password" = "Contraseña:";
+"login-view.email-placeholder" = "Email";
+"login-view.password-placeholder" = "Contraseña";
+"login-view.login-button-title" = "INGRESAR";
+"login-view.recover-password-button-title" = "Recuperar contraseña";
 "login-view.to-signup-label" = "¿Eres nuevo?";
-"login-view-model.signup-button-title" = "Crea una cuenta";
+"login-view.signup-button-title" = "Crear una cuenta";
 
 /* Errores del servicio de sesión */
 "login-error.invalid-credentials.message" = "Email o contraseña incorrectos";

--- a/Authentication/Supporting Files/es.lproj/Spanish(es).strings
+++ b/Authentication/Supporting Files/es.lproj/Spanish(es).strings
@@ -10,10 +10,10 @@
 "text-input-validator.empty" = "No puede dejarse vacío";
 "text-input-validator.max-length" = "No puede ser más largo que %d caracteres";
 "text-input-validator.min-length" = "No puede ser más corto que %d caracteres";
-"text-input-validator.invalid-email" = "Debe ser un email válido (Por ejemplo, usuario@mail.com)";
+"text-input-validator.invalid-email" = "Debe ser un email válido";
 
 /* Text visibility */
-"text-visibility-button-title.false" = "Ocultar";ß
+"text-visibility-button-title.false" = "Ocultar";
 "text-visibility-button-title.true" = "Mostrar";
 
 /* Títulos de los elementos de UI del login */
@@ -22,9 +22,9 @@
 "login-view-model.email-placeholder" = "Email";
 "login-view-model.password-placeholder" = "Contraseña";
 "login-view-model.login-button-title" = "INGRESAR";
-"login-view-model.signup-button-title" = "Regístrese";
 "login-view-model.recover-password-button-title" = "Recuperar contraseña";
-"login-view.to-signup-label" = "¿No tienes cuenta?";
+"login-view.to-signup-label" = "¿Eres nuevo?";
+"login-view-model.signup-button-title" = "Crea una cuenta";
 
 /* Errores del servicio de sesión */
 "login-error.invalid-credentials.message" = "Email o contraseña incorrectos";
@@ -36,7 +36,7 @@
 "login-error.alert.close" = "Cerrar";
 
 /* Títulos de los elementos de UI del signup */
-"signup-view.title" = "Regístrese";
+"signup-view.title" = "Registrate";
 "signup-view.name" = "Nombre:";
 "signup-view.email" = "Email:";
 "signup-view.password" = "Contraseña:";
@@ -45,15 +45,12 @@
 "signup-view.email-placeholder" = "Email";
 "signup-view.password-placeholder" = "Contraseña";
 "signup-view.confirm-password-placeholder" = "Confirme contraseña";
-"signup-view.terms-and-services.text" = "Al registrarme, acepto los Términos y Servicios.";
-"signup-view.terms-and-services.link-text" = "Términos y Servicios";
+"signup-view.terms-and-services.text" = "Al registrarme acepto los Términos y Condiciones.";
+"signup-view.terms-and-services.link-text" = "Términos y Condiciones";
 "signup-view.terms-and-services.link-url" = "";
-"signup-view.signup-button-title" = "REGISTRARSE";
-"signup-view.login.label-text" = "¿Ya está registrado?";
-"signup-view.login.button-title" = "Inicie sesión";
-
-/* Errores de signup */
-"signup-error.password-confirmation.invalid" = "Las contraseñas no coinciden";
+"signup-view.signup-button-title" = "REGISTRARME";
+"signup-view.login.label-text" = "¿Ya tienes cuenta?";
+"signup-view.login.button-title" = "Ingresá";
 
 /* Errores de signup */
 "signup-error.password-confirmation.invalid" = "Las contraseñas no coinciden";

--- a/Authentication/Validators/CompositeValidator.swift
+++ b/Authentication/Validators/CompositeValidator.swift
@@ -6,8 +6,18 @@
 //  Copyright © 2016 Wolox. All rights reserved.
 //
 
-import Foundation
 
+/*
+     Represents a composite validator which
+     will validate according to all criteria
+     embedded in all the TextInputValidator s
+     associated.
+     A text is valid only when it is valid for
+     all and each of the validators associated.
+     An invalid text will be accompanied by all
+     the invalid errors provided by the validators
+     associated.
+ */
 public struct CompositeTextInputValidator: TextInputValidatorType {
     
     private let _validators: [TextInputValidatorType]

--- a/Authentication/Validators/ConstantValidators.swift
+++ b/Authentication/Validators/ConstantValidators.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2016 Wolox. All rights reserved.
 //
 
+/*
+     Represents a validator which will consider
+     any input valid.
+ */
 public struct AlwaysValidValidator: TextInputValidatorType {
     
     public func validate(text: String) -> ValidationResult {
@@ -14,6 +18,13 @@ public struct AlwaysValidValidator: TextInputValidatorType {
     
 }
 
+/*
+     Represents a validator which will consider
+     any input invalid.
+     It provides an errorTextToLocalize property
+     to customize the error message associated
+     with the invalidity, to explain its reason.
+ */
 public struct AlwaysInvalidValidator: TextInputValidatorType {
     
     public var errorTextToLocalize: String = ""

--- a/Authentication/Validators/EmailValidator.swift
+++ b/Authentication/Validators/EmailValidator.swift
@@ -6,8 +6,10 @@
 //  Copyright © 2016 Wolox. All rights reserved.
 //
 
-import Foundation
-
+/*
+     Represents an email validator,
+     according to the Email's valid criteria.
+ */
 public struct EmailValidator: TextInputValidatorType {
     
     public func validate(text: String) -> ValidationResult {

--- a/Authentication/Validators/InlineValidator.swift
+++ b/Authentication/Validators/InlineValidator.swift
@@ -6,9 +6,10 @@
 //  Copyright © 2016 Wolox. All rights reserved.
 //
 
-import Foundation
-
-
+/*
+     Represents a validator which will validate
+     according to the validating function associated.
+ */
 public struct AnyTextInputValidator: TextInputValidatorType {
     
     private let _validate: String -> ValidationResult

--- a/Authentication/Validators/LengthValidators.swift
+++ b/Authentication/Validators/LengthValidators.swift
@@ -8,6 +8,10 @@
 
 import Foundation
 
+/*
+     Represents a validator which will validate
+     the text is not empty.
+ */
 public struct NonEmptyValidator: TextInputValidatorType {
     
     public func validate(text: String) -> ValidationResult {
@@ -20,6 +24,13 @@ public struct NonEmptyValidator: TextInputValidatorType {
     
 }
 
+/*
+     Represents a validator which will validate
+     the text is no longer than the quantity of
+     characters associated.
+     (That is to say, any text with that exact 
+     quantity or less is valid)
+ */
 public struct MaxLengthValidator: TextInputValidatorType {
     
     private let _maxLength: Int
@@ -38,6 +49,13 @@ public struct MaxLengthValidator: TextInputValidatorType {
     
 }
 
+/*
+     Represents a validator which will validate
+     the text is no shorter than the quantity of
+     characters associated.
+     (That is to say, any text with that exact
+     quantity or more is valid)
+ */
 public struct MinLengthValidator: TextInputValidatorType {
     
     private let _minLength: Int

--- a/Authentication/Validators/TextInputValidatorType.swift
+++ b/Authentication/Validators/TextInputValidatorType.swift
@@ -8,7 +8,10 @@
 
 import Foundation
 
-
+/*
+     Represents any possible validation result:
+     valid, or invalid with any possibe quantity of errors.
+ */
 public enum ValidationResult {
     
     public static func invalid(errorMessage: String) -> ValidationResult {
@@ -38,6 +41,9 @@ public enum ValidationResult {
     
 }
 
+/*
+     Represents any text validator.
+ */
 public protocol TextInputValidatorType {
     
     func validate(text: String) -> ValidationResult

--- a/Authentication/ViewProtocols.swift
+++ b/Authentication/ViewProtocols.swift
@@ -96,6 +96,7 @@ public protocol SignupFormType: AuthenticationFormType {
     var usernameLabel: UILabel? { get }
     var usernameTextField: UITextField? { get }
     var usernameValidationMessageLabel: UILabel? { get }
+    func hideUsernameElements()
     
     var usernameTextFieldValid: Bool { get set }
     var usernameTextFieldSelected: Bool { get set }
@@ -104,6 +105,7 @@ public protocol SignupFormType: AuthenticationFormType {
     var passwordConfirmTextField: UITextField? { get }
     var passwordConfirmValidationMessageLabel: UILabel? { get }
     var passwordConfirmVisibilityButton: UIButton? { get }
+    func hidePasswordConfirmElements()
     
     var passwordConfirmationTextFieldValid: Bool { get set }
     var passwordConfirmationTextFieldSelected: Bool { get set }

--- a/Authentication/ViewProtocols.swift
+++ b/Authentication/ViewProtocols.swift
@@ -117,8 +117,7 @@ public protocol SignupFormType: AuthenticationFormType {
     var signUpButtonEnabled: Bool { get set }
     var signUpButtonPressed: Bool { get set }
     
-    var termsAndServicesButton: UIButton { get }
-    var termsAndServicesLabel: UILabel? { get }
+    var termsAndServicesTextView: UITextView { get }
     
 }
 
@@ -134,7 +133,5 @@ public extension SignupFormType {
     var passwordConfirmVisibilityButton: UIButton? { return .None }
     
     var signUpErrorLabel: UILabel? { return .None }
-    
-    var termsAndServicesLabel: UILabel? { return .None }
     
 }

--- a/Authentication/ViewProtocols.swift
+++ b/Authentication/ViewProtocols.swift
@@ -52,6 +52,17 @@ public protocol AuthenticationFormType {
     
 }
 
+public extension AuthenticationFormType {
+    
+    var emailLabel: UILabel? { return .None }
+    var emailValidationMessageLabel: UILabel? { return .None }
+    
+    var passwordLabel: UILabel? { return .None }
+    var passwordValidationMessageLabel: UILabel? { return .None }
+    var passwordVisibilityButton: UIButton? { return .None }
+    
+}
+
 /*
      Represents a login form with its
      minimum elements necessary to
@@ -66,6 +77,12 @@ public protocol LoginFormType: AuthenticationFormType {
     var logInButtonEnabled: Bool { get set }
     var logInButtonPressed: Bool { get set }
 
+}
+
+public extension LoginFormType {
+    
+    var logInErrorLabel: UILabel? { return .None }
+    
 }
 
 /*
@@ -100,5 +117,22 @@ public protocol SignupFormType: AuthenticationFormType {
     
     var termsAndServicesButton: UIButton { get }
     var termsAndServicesLabel: UILabel? { get }
+    
+}
+
+public extension SignupFormType {
+    
+    var usernameLabel: UILabel? { return .None }
+    var usernameTextField: UITextField? { return .None }
+    var usernameValidationMessageLabel: UILabel? { return .None }
+    
+    var passwordConfirmLabel: UILabel? { return .None }
+    var passwordConfirmTextField: UITextField? { return .None }
+    var passwordConfirmValidationMessageLabel: UILabel? { return .None }
+    var passwordConfirmVisibilityButton: UIButton? { return .None }
+    
+    var signUpErrorLabel: UILabel? { return .None }
+    
+    var termsAndServicesLabel: UILabel? { return .None }
     
 }

--- a/Authentication/ViewProtocols.swift
+++ b/Authentication/ViewProtocols.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2016 Wolox. All rights reserved.
 //
 
+/**
+     Represents something that can give us an
+     UIView to show and render.
+ */
 public protocol Renderable {
     
     var view: UIView { get }
@@ -22,7 +26,12 @@ public extension Renderable where Self: UIView {
     
 }
 
-
+/**
+     Represents an authentication form
+     with its minimum elements necessary
+     to be able to authenticate, and
+     properties to handle its states.
+ */
 public protocol AuthenticationFormType {
     
     var emailLabel: UILabel? { get }
@@ -43,6 +52,12 @@ public protocol AuthenticationFormType {
     
 }
 
+/**
+     Represents a login form with its
+     minimum elements necessary to
+     authenticate and start login action,
+     and properties to handle its states.
+ */
 public protocol LoginFormType: AuthenticationFormType {
 
     var logInButton: UIButton { get }
@@ -53,6 +68,12 @@ public protocol LoginFormType: AuthenticationFormType {
 
 }
 
+/**
+     Represents a signup form with its
+     most common elements used to
+     authenticate and start signup action,
+     and properties to handle its states.
+ */
 public protocol SignupFormType: AuthenticationFormType {
 
     var usernameLabel: UILabel? { get }

--- a/Authentication/ViewProtocols.swift
+++ b/Authentication/ViewProtocols.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Wolox. All rights reserved.
 //
 
-/**
+/*
      Represents something that can give us an
      UIView to show and render.
  */
@@ -26,7 +26,7 @@ public extension Renderable where Self: UIView {
     
 }
 
-/**
+/*
      Represents an authentication form
      with its minimum elements necessary
      to be able to authenticate, and
@@ -52,7 +52,7 @@ public protocol AuthenticationFormType {
     
 }
 
-/**
+/*
      Represents a login form with its
      minimum elements necessary to
      authenticate and start login action,
@@ -68,7 +68,7 @@ public protocol LoginFormType: AuthenticationFormType {
 
 }
 
-/**
+/*
      Represents a signup form with its
      most common elements used to
      authenticate and start signup action,

--- a/AuthenticationDemo/AppDelegate.swift
+++ b/AuthenticationDemo/AppDelegate.swift
@@ -17,10 +17,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         // Override point for customization after application launch.
-        let loginConfiguration = LoginViewConfiguration(logoImage: UIImage(named: "agregar_contacto"))
+        let exampleSessionService = ExampleSessionService(email: "example@mail.com", password: "password")
         
-        authenticationBootstrapper = AuthenticationBootstrapper(sessionService: ExampleSessionService(email: "example@mail.com", password: "password"),
-            window: window!, viewConfiguration: AuthenticationViewConfiguration(loginViewConfiguration: loginConfiguration)) {
+        let loginConfiguration = LoginViewConfiguration(logoImage: UIImage(named: "agregar_contacto"))
+        let signupConfiguration = SignupViewConfiguration(usernameEnabled: true, passwordConfirmationEnabled: true)
+        let authenticationConfiguration = AuthenticationViewConfiguration(loginViewConfiguration: loginConfiguration, signupViewConfiguration: signupConfiguration)
+        
+        authenticationBootstrapper = AuthenticationBootstrapper(sessionService: exampleSessionService, window: window!, viewConfiguration: authenticationConfiguration) {
             let storyboard = UIStoryboard(name: "Main", bundle: nil)
             return storyboard.instantiateViewControllerWithIdentifier("ExampleMainViewController") as! ExampleMainViewController // swiftlint:disable:this force_cast
         }

--- a/AuthenticationDemo/AppDelegate.swift
+++ b/AuthenticationDemo/AppDelegate.swift
@@ -17,7 +17,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         // Override point for customization after application launch.
-        let loginConfiguration = DefaultLoginViewConfiguration(logoImage: UIImage(named: "agregar_contacto"))
+        let loginConfiguration = LoginViewConfiguration(logoImage: UIImage(named: "agregar_contacto"))
         
         authenticationBootstrapper = AuthenticationBootstrapper(sessionService: ExampleSessionService(email: "example@mail.com", password: "password"),
             window: window!, viewConfiguration: AuthenticationViewConfiguration(loginViewConfiguration: loginConfiguration)) {

--- a/AuthenticationDemo/ExampleSessionService.swift
+++ b/AuthenticationDemo/ExampleSessionService.swift
@@ -84,7 +84,7 @@ public final class ExampleSessionService: SessionServiceType {
         })
     }
     
-    public func signUp(name: String, email: Email, password: String) -> SignalProducer<ExampleUser, SessionServiceError> {
+    public func signUp(name: String?, email: Email, password: String) -> SignalProducer<ExampleUser, SessionServiceError> {
         let dispatchTime = dispatch_time(DISPATCH_TIME_NOW, (Int64)(2 * NSEC_PER_SEC))
         if email.raw == _email {
             if _registeredAlready {

--- a/AuthenticationTests/LogIn/LoginViewModelTests.swift
+++ b/AuthenticationTests/LogIn/LoginViewModelTests.swift
@@ -33,7 +33,7 @@ class LoginViewModelSpec: QuickSpec {
             }
             
             it("starts without showing password") {
-                expect(loginVM.showPassword.value) == false
+                expect(loginVM.passwordVisible.value) == false
             }
             
             context("when filling email with invalid email") {

--- a/AuthenticationTests/LogIn/Mocks/MockSessionService.swift
+++ b/AuthenticationTests/LogIn/Mocks/MockSessionService.swift
@@ -42,7 +42,7 @@ final class MockSessionService: SessionServiceType {
         }
     }
     
-    func signUp(name: String, email: Email, password: String) -> SignalProducer<MyUser, SessionServiceError> {
+    func signUp(name: String?, email: Email, password: String) -> SignalProducer<MyUser, SessionServiceError> {
         return SignalProducer.empty
     }
     


### PR DESCRIPTION
# Sumary
**Trello card**: https://trello.com/c/VebrLt5b/34-correcciones-a-las-vistas

Correcting wording.
Making terms and services a textview.
Underlining navigation buttons' title.
In signup, making username and password confirmation textfields optional but included in default view.

# Screenshots 

## Wording - iPhone 6s+

### English
![simulator screen shot jul 25 2016 1 58 38 pm](https://cloud.githubusercontent.com/assets/12351004/17110342/efe44340-5272-11e6-954a-319176f1a85c.png)
![simulator screen shot jul 25 2016 2 14 20 pm](https://cloud.githubusercontent.com/assets/12351004/17110344/f12b1620-5272-11e6-830e-0571f6289952.png)

### Spanish
![simulator screen shot jul 25 2016 2 15 28 pm](https://cloud.githubusercontent.com/assets/12351004/17110348/f3c19ddc-5272-11e6-88a8-f375efdc706e.png)
![simulator screen shot jul 25 2016 2 00 28 pm](https://cloud.githubusercontent.com/assets/12351004/17110349/f4cd1364-5272-11e6-8a80-f75df5719d32.png)


# Screencast 
 (The wording in the screencast is not the final one)
## Username enabled
![username enabled](https://cloud.githubusercontent.com/assets/12351004/17110434/517f2476-5273-11e6-9626-bbecc24ca275.gif)

## Password confirmation enabled
![password confirmation enabled](https://cloud.githubusercontent.com/assets/12351004/17110472/82064fd4-5273-11e6-8640-404a12907eb6.gif)


## Username and Password confirmation enabled
![username and password confirmation enabled](https://cloud.githubusercontent.com/assets/12351004/17110473/85221144-5273-11e6-9c47-c7251eba362f.gif)


