### PR TITLE
Making initial screen selectable by user between login and signup

### DIFF
--- a/Authentication/AuthenticationBootstrapper.swift
+++ b/Authentication/AuthenticationBootstrapper.swift
@@ -8,6 +8,10 @@
 
 import Core
 
+public enum AuthenticationInitialScreen {
+    case Login, Signup
+}
+
 /**
     Bootstrapper to start the application.
     Takes care of starting the authentication process before the main View Controller of the app when necessary,
@@ -28,7 +32,9 @@ public class AuthenticationBootstrapper<User: UserType, SessionService: SessionS
     /// The configuration that defines colour and fonts and assets, like the logo, used in the views.
     /// It also includes other configurations like the textfields selected to use in signup.
     private let _viewConfiguration: AuthenticationViewConfiguration
-
+    /// Property indicating the authentication screen to be shown the first time.
+    private let _initialScreen: AuthenticationInitialScreen
+    
     
     /**
         Initializes a new authentication bootstrapper with the session service to use for logging in and out and
@@ -41,15 +47,18 @@ public class AuthenticationBootstrapper<User: UserType, SessionService: SessionS
                 It can be remote or local.
             - viewConfiguration: all configuration needed to setup all authentication views.
                 By default, it uses each view's default configuration.
+            - initialScreen: Authentication screen to be shown the first time. By default, Login.
             - mainViewControllerFactory: Method that returns a valid mainViewController to use when starting the
-            core of the app
+                core of the app.
     */
     public init(sessionService: SessionService, window: UIWindow,
                 viewConfiguration: AuthenticationViewConfiguration,
+                initialScreen: AuthenticationInitialScreen = .Login,
                 mainViewControllerFactory: () -> UIViewController) {
         _window = window
         _mainViewControllerFactory = mainViewControllerFactory
         _viewConfiguration = viewConfiguration
+        _initialScreen = initialScreen
         self.sessionService = sessionService
 
         sessionService.events.observeNext { [unowned self] event in
@@ -78,7 +87,8 @@ public class AuthenticationBootstrapper<User: UserType, SessionService: SessionS
         if let _ = self.currentUser {
             _window.rootViewController = _mainViewControllerFactory()
         } else {
-            _window.rootViewController = UINavigationController(rootViewController: createLoginController())
+            let mainAuthenticationController = _initialScreen == .Login ? createLoginController() : createSignupController()
+            _window.rootViewController = UINavigationController(rootViewController: mainAuthenticationController)
         }
     }
     
@@ -392,31 +402,17 @@ public extension AuthenticationBootstrapper {
 
 extension AuthenticationBootstrapper: LoginControllerTransitionDelegate {
     
-    /**
-         Function that reacts to the user pressing "Sign Up" in the
-         login screen.
-     
-         It will push the new controller in the navigation controller.
-     
-         - Parameter controller: LoginController active when calling this.
-     */
-    public final func onSignup(controller: LoginController) {
-        let signupController = createSignupController()
-        // The authentication framework starts the process with a navigation controller.
-        controller.navigationController!.pushViewController(signupController, animated: true)
+    public func onSignup(controller: LoginController) {
+        if _initialScreen == .Login {
+            let signupController = createSignupController()
+            controller.navigationController!.pushViewController(signupController, animated: true)
+        } else {
+            controller.navigationController!.popViewControllerAnimated(true)
+        }
     }
     
-    /**
-         Function that reacts to the user pressing "Recover Password"
-         in the login screen.
-     
-         It will push the new controller in the navigation controller.
-     
-         - Parameter controller: LoginController active when calling this.
-     */
     public final func onRecoverPassword(controller: LoginController) {
         let recoverPasswordController = createRecoverPasswordController()
-        // The authentication framework starts the process with a navigation controller.
         controller.navigationController!.pushViewController(recoverPasswordController, animated: true)
     }
     
@@ -424,27 +420,18 @@ extension AuthenticationBootstrapper: LoginControllerTransitionDelegate {
 
 extension AuthenticationBootstrapper: SignupControllerTransitionDelegate {
     
-    /**
-         Function that reacts to the user pressing "Log In"
-         in the signup screen.
-     
-         It will pop the signup controller from the navigation controller,
-         to return to login screen.
-     
-         - Parameter controller: SignupController active when calling this.
-     */
-    public final func onLogin(controller: SignupController) {
-        // The authentication framework starts the process with a navigation controller.
-        controller.navigationController!.popViewControllerAnimated(true)
+    public func onLogin(controller: SignupController) {
+        if _initialScreen == .Signup {
+            let loginController = createLoginController()
+            controller.navigationController!.pushViewController(loginController, animated: true)
+        } else {
+            controller.navigationController!.popViewControllerAnimated(true)
+        }
     }
     
     public func onTermsAndServices(controller: SignupController) {
         let termsAndServicesController = createTermsAndServicesController(_viewConfiguration.signupConfiguration.termsAndServicesURL)
-        if let navigationController = controller.navigationController {
-            navigationController.pushViewController(termsAndServicesController, animated: true)
-        } else {
-            _window.rootViewController = UINavigationController(rootViewController: termsAndServicesController)
-        }
+        controller.navigationController!.pushViewController(termsAndServicesController, animated: true)
     }
     
 }

--- a/Authentication/AuthenticationBootstrapper.swift
+++ b/Authentication/AuthenticationBootstrapper.swift
@@ -408,7 +408,7 @@ public extension AuthenticationBootstrapper {
 
 extension AuthenticationBootstrapper: LoginControllerTransitionDelegate {
     
-    public func onSignup(controller: LoginController) {
+    public func toSignup(controller: LoginController) {
         if _initialScreen == .Login {
             let signupController = createSignupController()
             controller.navigationController!.pushViewController(signupController, animated: true)
@@ -417,7 +417,7 @@ extension AuthenticationBootstrapper: LoginControllerTransitionDelegate {
         }
     }
     
-    public final func onRecoverPassword(controller: LoginController) {
+    public final func toRecoverPassword(controller: LoginController) {
         let recoverPasswordController = createRecoverPasswordController()
         controller.navigationController!.pushViewController(recoverPasswordController, animated: true)
     }
@@ -426,7 +426,7 @@ extension AuthenticationBootstrapper: LoginControllerTransitionDelegate {
 
 extension AuthenticationBootstrapper: SignupControllerTransitionDelegate {
     
-    public func onLogin(controller: SignupController) {
+    public func toLogin(controller: SignupController) {
         if _initialScreen == .Signup {
             let loginController = createLoginController()
             controller.navigationController!.pushViewController(loginController, animated: true)

--- a/Authentication/AuthenticationBootstrapper.swift
+++ b/Authentication/AuthenticationBootstrapper.swift
@@ -8,6 +8,12 @@
 
 import Core
 
+/*
+    Enumeration representing an authentication screen
+    that can be used as the starting point of
+    authentication process.
+ */
+
 public enum AuthenticationInitialScreen {
     case Login, Signup
 }

--- a/Authentication/Login/View/LoginConfiguration.swift
+++ b/Authentication/Login/View/LoginConfiguration.swift
@@ -11,9 +11,9 @@
 */
 public protocol LoginControllerTransitionDelegate {
     
-    func onSignup(controller: LoginController)
+    func toSignup(controller: LoginController)
     
-    func onRecoverPassword(controller: LoginController)
+    func toRecoverPassword(controller: LoginController)
     
 }
 

--- a/Authentication/Login/View/LoginController.swift
+++ b/Authentication/Login/View/LoginController.swift
@@ -144,8 +144,8 @@ private extension LoginController {
     private func bindButtons() {
         loginView.logInButton.rex_pressed.value = _viewModel.logInCocoaAction
         loginView.logInButton.rex_enabled.signal.observeNext { [unowned self] in self.loginView.logInButtonEnabled = $0 }
-        loginView.signupButton.setAction { [unowned self] _ in self._transitionDelegate.onSignup(self) }
-        loginView.recoverPasswordButton.setAction { [unowned self] _ in self._transitionDelegate.onRecoverPassword(self) }
+        loginView.signupButton.setAction { [unowned self] _ in self._transitionDelegate.toSignup(self) }
+        loginView.recoverPasswordButton.setAction { [unowned self] _ in self._transitionDelegate.toRecoverPassword(self) }
     }
     
     private func setTextfieldOrder() {

--- a/Authentication/SignUp/View/SignupConfiguration.swift
+++ b/Authentication/SignUp/View/SignupConfiguration.swift
@@ -11,7 +11,7 @@
  */
 public protocol SignupControllerTransitionDelegate {
     
-    func onLogin(controller: SignupController)
+    func toLogin(controller: SignupController)
     
     func onTermsAndServices(controller: SignupController)
     

--- a/Authentication/SignUp/View/SignupController.swift
+++ b/Authentication/SignUp/View/SignupController.swift
@@ -71,6 +71,7 @@ public final class SignupController: UIViewController {
         super.viewDidLoad()
         signupView.render()
         bindViewModel()
+        navigationController?.navigationBarHidden = true
         let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
         view.addGestureRecognizer(tapRecognizer)
     }

--- a/Authentication/SignUp/View/SignupController.swift
+++ b/Authentication/SignUp/View/SignupController.swift
@@ -188,7 +188,7 @@ private extension SignupController {
     private func bindButtons() {
         signupView.signUpButton.rex_pressed.value = _viewModel.signUpCocoaAction
         signupView.signUpButton.rex_enabled.signal.observeNext { [unowned self] in self.signupView.signUpButtonEnabled = $0 }
-        signupView.loginButton.setAction { [unowned self] _ in self._transitionDelegate.onLogin(self) }
+        signupView.loginButton.setAction { [unowned self] _ in self._transitionDelegate.toLogin(self) }
         bindTermsAndServices()
     }
     

--- a/AuthenticationDemo/AppDelegate.swift
+++ b/AuthenticationDemo/AppDelegate.swift
@@ -26,7 +26,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         authenticationBootstrapper = AuthenticationBootstrapper(sessionService: exampleSessionService,
                                                                 window: window!,
-                                                                viewConfiguration: authenticationConfiguration) {
+                                                                viewConfiguration: authenticationConfiguration,
+                                                                initialScreen: .Signup) {
             let storyboard = UIStoryboard(name: "Main", bundle: nil)
             return storyboard.instantiateViewControllerWithIdentifier("ExampleMainViewController") as! ExampleMainViewController // swiftlint:disable:this force_cast
         }

--- a/AuthenticationTests/Mocks/MockLoginTransitionDelegate.swift
+++ b/AuthenticationTests/Mocks/MockLoginTransitionDelegate.swift
@@ -11,8 +11,8 @@ import Authentication
 
 final class MockLoginTransitionDelegate: LoginControllerTransitionDelegate {
     
-    func onSignup(controller: LoginController) { }
+    func toSignup(controller: LoginController) { }
     
-    func onRecoverPassword(controller: LoginController) { }
+    func toRecoverPassword(controller: LoginController) { }
     
 }


### PR DESCRIPTION
## Sumary ##
**Trello card**: https://trello.com/c/184vqPn5/37-hacer-que-authentication-pueda-empezar-en-login-o-signup-a-eleccion

Making initial screen selectable by user between login and signup.
And making the navigation in the way: if not initial screen, popViewController.
It didn't include any visual change to views.

## Screencast ##

### Login first
![login first](https://cloud.githubusercontent.com/assets/12351004/17176902/349e2e2e-53e5-11e6-9e78-2a810246f518.gif)

### Signup first
![signup first](https://cloud.githubusercontent.com/assets/12351004/17176904/361beade-53e5-11e6-8634-4b97d7eba9e6.gif)
