### PR TITLE
Signup view model tests

### DIFF
--- a/Authentication.xcodeproj/project.pbxproj
+++ b/Authentication.xcodeproj/project.pbxproj
@@ -64,7 +64,7 @@
 		CE111E0F1D4FA8980083C99E /* AuthenticationViewConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE111E0C1D4FA8980083C99E /* AuthenticationViewConfiguration.swift */; };
 		CE111E101D4FA8980083C99E /* ColorPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE111E0D1D4FA8980083C99E /* ColorPalette.swift */; };
 		CE111E111D4FA8980083C99E /* FontPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE111E0E1D4FA8980083C99E /* FontPalette.swift */; };
-		CE111E131D4FC5890083C99E /* SignupViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE111E121D4FC5890083C99E /* SignupViewModelSpec.swift */; };
+		CE111E151D4FC8560083C99E /* SignupViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE111E141D4FC8560083C99E /* SignupViewModelTests.swift */; };
 		CE5248821D468D8200B499CC /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5248811D468D8200B499CC /* Extensions.swift */; };
 		CE5248871D468F8700B499CC /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = CE5248891D468F8700B499CC /* Localizable.strings */; };
 		CE7A7BB41D3E9AFC00C44A25 /* Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE7A7BB31D3E9AFC00C44A25 /* Core.framework */; };
@@ -196,7 +196,7 @@
 		CE111E0C1D4FA8980083C99E /* AuthenticationViewConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationViewConfiguration.swift; sourceTree = "<group>"; };
 		CE111E0D1D4FA8980083C99E /* ColorPalette.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorPalette.swift; sourceTree = "<group>"; };
 		CE111E0E1D4FA8980083C99E /* FontPalette.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FontPalette.swift; sourceTree = "<group>"; };
-		CE111E121D4FC5890083C99E /* SignupViewModelSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignupViewModelSpec.swift; sourceTree = "<group>"; };
+		CE111E141D4FC8560083C99E /* SignupViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignupViewModelTests.swift; sourceTree = "<group>"; };
 		CE5248811D468D8200B499CC /* Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		CE5248881D468F8700B499CC /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		CE7A7BB31D3E9AFC00C44A25 /* Core.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Core.framework; path = Carthage/Build/iOS/Core.framework; sourceTree = "<group>"; };
@@ -478,7 +478,7 @@
 		CE89A25A1CAEC68300E1903B /* Signup */ = {
 			isa = PBXGroup;
 			children = (
-				CE111E121D4FC5890083C99E /* SignupViewModelSpec.swift */,
+				CE111E141D4FC8560083C99E /* SignupViewModelTests.swift */,
 			);
 			path = Signup;
 			sourceTree = "<group>";
@@ -752,10 +752,10 @@
 			files = (
 				CE111DF11D4FA78E0083C99E /* LoginViewModelTests.swift in Sources */,
 				CE111DF01D4FA78E0083C99E /* LoginControllerTests.swift in Sources */,
+				CE111E151D4FC8560083C99E /* SignupViewModelTests.swift in Sources */,
 				CE111DAA1D4FA6C20083C99E /* MockSessionService.swift in Sources */,
 				CE111DFE1D4FA79A0083C99E /* NonEmptyValidatorTests.swift in Sources */,
 				CE111DA91D4FA6C20083C99E /* MockLoginTransitionDelegate.swift in Sources */,
-				CE111E131D4FC5890083C99E /* SignupViewModelSpec.swift in Sources */,
 				CE111DF91D4FA79A0083C99E /* AnyInputTextValidatorTests.swift in Sources */,
 				CE111DFD1D4FA79A0083C99E /* MinLengthValidatorTests.swift in Sources */,
 				CE111DFC1D4FA79A0083C99E /* MaxLengthValidatorTests.swift in Sources */,

--- a/Authentication.xcodeproj/project.pbxproj
+++ b/Authentication.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		CE111E0F1D4FA8980083C99E /* AuthenticationViewConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE111E0C1D4FA8980083C99E /* AuthenticationViewConfiguration.swift */; };
 		CE111E101D4FA8980083C99E /* ColorPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE111E0D1D4FA8980083C99E /* ColorPalette.swift */; };
 		CE111E111D4FA8980083C99E /* FontPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE111E0E1D4FA8980083C99E /* FontPalette.swift */; };
+		CE111E131D4FC5890083C99E /* SignupViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE111E121D4FC5890083C99E /* SignupViewModelSpec.swift */; };
 		CE5248821D468D8200B499CC /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5248811D468D8200B499CC /* Extensions.swift */; };
 		CE5248871D468F8700B499CC /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = CE5248891D468F8700B499CC /* Localizable.strings */; };
 		CE7A7BB41D3E9AFC00C44A25 /* Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE7A7BB31D3E9AFC00C44A25 /* Core.framework */; };
@@ -195,6 +196,7 @@
 		CE111E0C1D4FA8980083C99E /* AuthenticationViewConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationViewConfiguration.swift; sourceTree = "<group>"; };
 		CE111E0D1D4FA8980083C99E /* ColorPalette.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorPalette.swift; sourceTree = "<group>"; };
 		CE111E0E1D4FA8980083C99E /* FontPalette.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FontPalette.swift; sourceTree = "<group>"; };
+		CE111E121D4FC5890083C99E /* SignupViewModelSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignupViewModelSpec.swift; sourceTree = "<group>"; };
 		CE5248811D468D8200B499CC /* Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		CE5248881D468F8700B499CC /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		CE7A7BB31D3E9AFC00C44A25 /* Core.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Core.framework; path = Carthage/Build/iOS/Core.framework; sourceTree = "<group>"; };
@@ -476,6 +478,7 @@
 		CE89A25A1CAEC68300E1903B /* Signup */ = {
 			isa = PBXGroup;
 			children = (
+				CE111E121D4FC5890083C99E /* SignupViewModelSpec.swift */,
 			);
 			path = Signup;
 			sourceTree = "<group>";
@@ -752,6 +755,7 @@
 				CE111DAA1D4FA6C20083C99E /* MockSessionService.swift in Sources */,
 				CE111DFE1D4FA79A0083C99E /* NonEmptyValidatorTests.swift in Sources */,
 				CE111DA91D4FA6C20083C99E /* MockLoginTransitionDelegate.swift in Sources */,
+				CE111E131D4FC5890083C99E /* SignupViewModelSpec.swift in Sources */,
 				CE111DF91D4FA79A0083C99E /* AnyInputTextValidatorTests.swift in Sources */,
 				CE111DFD1D4FA79A0083C99E /* MinLengthValidatorTests.swift in Sources */,
 				CE111DFC1D4FA79A0083C99E /* MaxLengthValidatorTests.swift in Sources */,

--- a/Authentication/SignUp/View/SignupController.swift
+++ b/Authentication/SignUp/View/SignupController.swift
@@ -177,8 +177,8 @@ private extension SignupController {
                 passwordConfirmValidationMessageLabel.rex_text <~ _viewModel.passwordConfirmationValidationErrors.signal.map { $0.first ?? "" }
             }
             if let confirmPasswordVisibilityButton = signupView.passwordConfirmVisibilityButton {
-                confirmPasswordVisibilityButton.rex_pressed.value = _viewModel.toggleConfirmPasswordVisibility
-                _viewModel.confirmationPasswordVisible.signal.observeNext { [unowned self] in self.signupView.confirmationPasswordVisible = $0 }
+                confirmPasswordVisibilityButton.rex_pressed.value = _viewModel.togglePasswordConfirmVisibility
+                _viewModel.passwordConfirmationVisible.signal.observeNext { [unowned self] in self.signupView.passwordConfirmationVisible = $0 }
             }
             passwordConfirmationTextField.delegate = self
         }

--- a/Authentication/SignUp/View/SignupView.swift
+++ b/Authentication/SignUp/View/SignupView.swift
@@ -145,7 +145,7 @@ internal final class SignupView: UIView, SignupViewType, NibLoadable {
     
     internal var passwordConfirmationTextFieldValid = false { didSet { passwordConfirmationTextFieldValidWasSet() } }
     internal var passwordConfirmationTextFieldSelected = false { didSet { passwordConfirmationTextFieldSelectedWasSet() } }
-    internal var confirmationPasswordVisible = false { didSet { confirmationPasswordVisibleWasSet() } }
+    internal var passwordConfirmationVisible = false { didSet { confirmationPasswordVisibleWasSet() } }
     
     internal var signUpButtonEnabled = false { didSet { signUpButtonEnabledWasSet() } }
     internal var signUpButtonPressed = false { didSet { signUpButtonPressedWasSet() } }
@@ -190,7 +190,7 @@ internal final class SignupView: UIView, SignupViewType, NibLoadable {
         signUpButtonPressed = false
         
         passwordVisible = false
-        confirmationPasswordVisible = false
+        passwordConfirmationVisible = false
         
         delegate.configureView(self)
     }
@@ -281,7 +281,8 @@ private extension SignupView {
     }
     
     private func passwordVisibleWasSet() {
-        toggleVisibility(passwordTextFieldOutlet, visibilityButton: passwordVisibilityButtonOutlet, visibilityTitle: passwordVisibilityButtonTitle)
+        toggleVisibility(passwordTextFieldOutlet, visible: passwordVisible,
+                         visibilityButton: passwordVisibilityButtonOutlet, visibilityTitle: passwordVisibilityButtonTitle)
     }
     
     private func passwordConfirmationTextFieldValidWasSet() {
@@ -312,13 +313,14 @@ private extension SignupView {
     }
     
     private func confirmationPasswordVisibleWasSet() {
-        toggleVisibility(passwordConfirmTextFieldOutlet, visibilityButton: passwordConfirmVisibilityButtonOutlet, visibilityTitle: confirmPasswordVisibilityButtonTitle)
+        toggleVisibility(passwordConfirmTextFieldOutlet, visible: passwordConfirmationVisible,
+                         visibilityButton: passwordConfirmVisibilityButtonOutlet, visibilityTitle: confirmPasswordVisibilityButtonTitle)
     }
     
-    private func toggleVisibility(textField: UITextField, visibilityButton: UIButton, visibilityTitle: String) {
+    private func toggleVisibility(textField: UITextField, visible: Bool, visibilityButton: UIButton, visibilityTitle: String) {
         // Changing enabled property for the font setting to take effect, which is necessary for it not to shrink.
         textField.enabled = false
-        textField.secureTextEntry = !confirmationPasswordVisible
+        textField.secureTextEntry = !visible
         textField.enabled = true
         textField.font = delegate.fontPalette.textfields
         visibilityButton.setTitle(visibilityTitle, forState: .Normal)
@@ -364,7 +366,7 @@ public extension SignupViewType {
     
     public var passwordVisibilityButtonTitle: String { return ("text-visibility-button-title." + (passwordVisible ? "false" : "true")).frameworkLocalized }
     
-    public var confirmPasswordVisibilityButtonTitle: String { return ("text-visibility-button-title." + (confirmationPasswordVisible ? "false" : "true")).frameworkLocalized }
+    public var confirmPasswordVisibilityButtonTitle: String { return ("text-visibility-button-title." + (passwordConfirmationVisible ? "false" : "true")).frameworkLocalized }
     
     public var termsAndServicesText: String { return "signup-view.terms-and-services.text".frameworkLocalized }
     

--- a/Authentication/SignUp/ViewModel/SignupViewModel.swift
+++ b/Authentication/SignUp/ViewModel/SignupViewModel.swift
@@ -37,8 +37,8 @@ public protocol SignupViewModelType {
      errors and password visibility. */
     var passwordConfirmation: MutableProperty<String> { get }
     var passwordConfirmationValidationErrors: AnyProperty<[String]> { get }
-    var confirmationPasswordVisible: MutableProperty<Bool> { get }
-    var toggleConfirmPasswordVisibility: CocoaAction { get }
+    var passwordConfirmationVisible: MutableProperty<Bool> { get }
+    var togglePasswordConfirmVisibility: CocoaAction { get }
     
     /** Sign Up action considerations: action, executing state and errors. */
     var signUpCocoaAction: CocoaAction { get }
@@ -69,14 +69,14 @@ public final class SignupViewModel<User: UserType, SessionService: SessionServic
     public let passwordConfirmationValidationErrors: AnyProperty<[String]>
     
     public let passwordVisible = MutableProperty(false)
-    public let confirmationPasswordVisible = MutableProperty(false)
+    public let passwordConfirmationVisible = MutableProperty(false)
     
     public var signUpCocoaAction: CocoaAction { return _signUp.unsafeCocoaAction }
     public var signUpErrors: Signal<SessionServiceError, NoError> { return _signUp.errors }
     public var signUpExecuting: Signal<Bool, NoError> { return _signUp.executing.signal }
     
     public var togglePasswordVisibility: CocoaAction { return _togglePasswordVisibility.unsafeCocoaAction }
-    public var toggleConfirmPasswordVisibility: CocoaAction { return _toggleConfirmationPasswordVisibility.unsafeCocoaAction }
+    public var togglePasswordConfirmVisibility: CocoaAction { return _togglePasswordConfirmVisibility.unsafeCocoaAction }
     
     public let usernameEnabled: Bool
     public let passwordConfirmationEnabled: Bool
@@ -87,7 +87,7 @@ public final class SignupViewModel<User: UserType, SessionService: SessionServic
     private lazy var _signUp: Action<AnyObject, User, SessionServiceError> = self.initializeSignUpAction()
     
     private lazy var _togglePasswordVisibility: Action<AnyObject, Bool, NoError> = self.initializeTogglePasswordVisibilityAction()
-    private lazy var _toggleConfirmationPasswordVisibility: Action<AnyObject, Bool, NoError> = self.initializeToggleConfirmationPasswordVisibilityAction()
+    private lazy var _togglePasswordConfirmVisibility: Action<AnyObject, Bool, NoError> = self.initializeTogglePasswordConfirmationVisibilityAction()
     
     /**
          Initializes a signup view model which will communicate to the session service provided and
@@ -156,10 +156,10 @@ private extension SignupViewModel {
         }
     }
     
-    private func initializeToggleConfirmationPasswordVisibilityAction() -> Action<AnyObject, Bool, NoError> {
+    private func initializeTogglePasswordConfirmationVisibilityAction() -> Action<AnyObject, Bool, NoError> {
         return Action { [unowned self] _ in
-            self.confirmationPasswordVisible.value = !self.confirmationPasswordVisible.value
-            return SignalProducer(value: self.confirmationPasswordVisible.value).observeOn(UIScheduler())
+            self.passwordConfirmationVisible.value = !self.passwordConfirmationVisible.value
+            return SignalProducer(value: self.passwordConfirmationVisible.value).observeOn(UIScheduler())
         }
     }
     

--- a/Authentication/ViewProtocols.swift
+++ b/Authentication/ViewProtocols.swift
@@ -109,7 +109,7 @@ public protocol SignupFormType: AuthenticationFormType {
     
     var passwordConfirmationTextFieldValid: Bool { get set }
     var passwordConfirmationTextFieldSelected: Bool { get set }
-    var confirmationPasswordVisible: Bool { get set }
+    var passwordConfirmationVisible: Bool { get set }
     
     var signUpButton: UIButton { get }
     var signUpErrorLabel: UILabel? { get }

--- a/AuthenticationTests/LogIn/LoginControllerTests.swift
+++ b/AuthenticationTests/LogIn/LoginControllerTests.swift
@@ -26,7 +26,7 @@ class LoginViewControllerSpec: QuickSpec {
             var loginController: LoginController!
             
             beforeEach() {
-                sessionService = MockSessionService(email: Email(raw: "myuser@mail.com")!, password: "password", username: "MyUser")
+                sessionService = MockSessionService()
                 loginViewModel = LoginViewModel(sessionService: sessionService)
                 loginView = LoginView()
                 let configuration = LoginControllerConfiguration(viewModel: loginViewModel, viewFactory: { return loginView }, transitionDelegate: MockLoginTransitionDelegate())

--- a/AuthenticationTests/LogIn/LoginViewModelTests.swift
+++ b/AuthenticationTests/LogIn/LoginViewModelTests.swift
@@ -18,12 +18,12 @@ class LoginViewModelSpec: QuickSpec {
     
     override func spec() {
         describe("LoginViewModel") {
-            
+
             var sessionService: MockSessionService!
             var loginVM: LoginViewModel<MyUser, MockSessionService>!
             
             beforeEach() {
-                sessionService = MockSessionService(email: Email(raw: "myuser@mail.com")!, password: "password", username: "MyUser")
+                sessionService = MockSessionService()
                 loginVM = LoginViewModel(sessionService: sessionService)
             }
             
@@ -41,7 +41,6 @@ class LoginViewModelSpec: QuickSpec {
                 context("when email doesn't have @ character") {
                     
                     beforeEach() {
-                        loginVM = LoginViewModel(sessionService: sessionService)
                         loginVM.email.value = "my"
                     }
                     
@@ -62,7 +61,6 @@ class LoginViewModelSpec: QuickSpec {
                 context("when email is empty") {
                     
                     beforeEach() {
-                        loginVM = LoginViewModel(sessionService: sessionService)
                         loginVM.email.value = "my"
                         loginVM.email.value = ""
                     }
@@ -89,7 +87,6 @@ class LoginViewModelSpec: QuickSpec {
                 context("when password is shorter than expected") {
                     
                     beforeEach() {
-                        loginVM = LoginViewModel(sessionService: sessionService)
                         loginVM.password.value = "my"
                     }
                     
@@ -110,7 +107,6 @@ class LoginViewModelSpec: QuickSpec {
                 context("when password is longer than expected") {
                     
                     beforeEach() {
-                        loginVM = LoginViewModel(sessionService: sessionService)
                         loginVM.password.value = "myVeryLongPasswordWithMoreThan30Characters"
                     }
                     
@@ -131,7 +127,6 @@ class LoginViewModelSpec: QuickSpec {
                 context("when password is empty") {
                     
                     beforeEach() {
-                        loginVM = LoginViewModel(sessionService: sessionService)
                         loginVM.password.value = "my"
                         loginVM.password.value = ""
                     }
@@ -157,7 +152,6 @@ class LoginViewModelSpec: QuickSpec {
                 context("when email and password are wrong") {
                     
                     beforeEach() {
-                        loginVM = LoginViewModel(sessionService: sessionService)
                         loginVM.email.value = "wrong@email.com"
                         loginVM.password.value = "wrongPassword"
                     }
@@ -171,27 +165,16 @@ class LoginViewModelSpec: QuickSpec {
                         expect(loginVM.logInCocoaAction.enabled) == true
                     }
                     
-                    it("returns logIn credentials error") { waitUntil { done in
-                        sessionService.events.observeNext { event in
-                            switch event {
-                            case .LogInError(let error):
-                                switch error {
-                                case .InvalidLogInCredentials(_):
-                                    done()
-                                default: break
-                                }
-                            default: break
-                            }
-                        }
+                    it("calls session service's signup") { waitUntil { done in
+                        sessionService.logInCalled.observeNext { _ in done() }
                         loginVM.logInCocoaAction.execute("")
                     }}
                     
                 }
                 
-                context("when emailis correct but password is wrong") {
+                context("when email is correct but password is wrong") {
                     
                     beforeEach() {
-                        loginVM = LoginViewModel(sessionService: sessionService)
                         loginVM.email.value = "myuser@mail.com"
                         loginVM.password.value = "wrongPassword"
                     }
@@ -205,18 +188,8 @@ class LoginViewModelSpec: QuickSpec {
                         expect(loginVM.logInCocoaAction.enabled) == true
                     }
                     
-                    it("returns logIn credentials error") { waitUntil { done in
-                        sessionService.events.observeNext { event in
-                            switch event {
-                            case .LogInError(let error):
-                                switch error {
-                                case .InvalidLogInCredentials(_):
-                                    done()
-                                default: break
-                                }
-                            default: break
-                            }
-                        }
+                    it("calls session service's signup") { waitUntil { done in
+                        sessionService.logInCalled.observeNext { _ in done() }
                         loginVM.logInCocoaAction.execute("")
                     }}
                     
@@ -225,7 +198,6 @@ class LoginViewModelSpec: QuickSpec {
                 context("when email is wrong and password is correct") {
                     
                     beforeEach() {
-                        loginVM = LoginViewModel(sessionService: sessionService)
                         loginVM.email.value = "wrong@email.com"
                         loginVM.password.value = "password"
                     }
@@ -239,18 +211,8 @@ class LoginViewModelSpec: QuickSpec {
                         expect(loginVM.logInCocoaAction.enabled) == true
                     }
                     
-                    it("returns logIn credentials error") { waitUntil { done in
-                        sessionService.events.observeNext { event in
-                            switch event {
-                            case .LogInError(let error):
-                                switch error {
-                                case .InvalidLogInCredentials(_):
-                                    done()
-                                default: break
-                                }
-                            default: break
-                            }
-                        }
+                    it("calls session service's signup") { waitUntil { done in
+                        sessionService.logInCalled.observeNext { _ in done() }
                         loginVM.logInCocoaAction.execute("")
                     }}
                     
@@ -259,7 +221,6 @@ class LoginViewModelSpec: QuickSpec {
                 context("when email and password are correct") {
                     
                     beforeEach() {
-                        loginVM = LoginViewModel(sessionService: sessionService)
                         loginVM.email.value = "myuser@mail.com"
                         loginVM.password.value = "password"
                     }
@@ -273,24 +234,14 @@ class LoginViewModelSpec: QuickSpec {
                         expect(loginVM.logInCocoaAction.enabled) == true
                     }
                     
-                    it("returns logInUser") { waitUntil { done in
-                        sessionService.events.observeNext { event in
-                            switch event {
-                            case .LogIn(let user):
-                                expect(user.email.raw) == "myuser@mail.com"
-                                expect(user.password) == "password"
-                                expect(user.username) == "MyUser"
-                                done()
-                            default: break
-                            }
-                        }
+                    it("calls session service's signup") { waitUntil { done in
+                        sessionService.logInCalled.observeNext { _ in done() }
                         loginVM.logInCocoaAction.execute("")
                     }}
                     
                 }
                 
             }
-            
             
         }
     }

--- a/AuthenticationTests/LogIn/LoginViewModelTests.swift
+++ b/AuthenticationTests/LogIn/LoginViewModelTests.swift
@@ -36,6 +36,31 @@ class LoginViewModelSpec: QuickSpec {
                 expect(loginVM.passwordVisible.value) == false
             }
             
+            describe("#togglePasswordVisibility") {
+                
+                context("when executing action") {
+                    
+                    it("should change #passwordVisible from false to true") { waitUntil { done in
+                        loginVM.passwordVisible.signal.take(1).observeNext {
+                            expect($0) == true
+                            done()
+                        }
+                        loginVM.togglePasswordVisibility.execute("")
+                    }}
+                    
+                    it("should change #passwordVisible from true to false") { waitUntil { done in
+                        loginVM.passwordVisible.signal.take(2).skip(1).observeNext {
+                            expect($0) == false
+                            done()
+                        }
+                        loginVM.togglePasswordVisibility.execute("")
+                        loginVM.togglePasswordVisibility.execute("")
+                    }}
+                    
+                }
+                
+            }
+            
             context("when filling email with invalid email") {
                 
                 context("when email doesn't have @ character") {

--- a/AuthenticationTests/LogIn/LoginViewModelTests.swift
+++ b/AuthenticationTests/LogIn/LoginViewModelTests.swift
@@ -20,20 +20,20 @@ class LoginViewModelSpec: QuickSpec {
         describe("LoginViewModel") {
 
             var sessionService: MockSessionService!
-            var loginVM: LoginViewModel<MyUser, MockSessionService>!
+            var loginViewModel: LoginViewModel<MyUser, MockSessionService>!
             
             beforeEach() {
                 sessionService = MockSessionService()
-                loginVM = LoginViewModel(sessionService: sessionService)
+                loginViewModel = LoginViewModel(sessionService: sessionService)
             }
             
             it("starts without errors") {
-                expect(loginVM.emailValidationErrors.value) == []
-                expect(loginVM.passwordValidationErrors.value) == []
+                expect(loginViewModel.emailValidationErrors.value) == []
+                expect(loginViewModel.passwordValidationErrors.value) == []
             }
             
             it("starts without showing password") {
-                expect(loginVM.passwordVisible.value) == false
+                expect(loginViewModel.passwordVisible.value) == false
             }
             
             describe("#togglePasswordVisibility") {
@@ -41,20 +41,20 @@ class LoginViewModelSpec: QuickSpec {
                 context("when executing action") {
                     
                     it("should change #passwordVisible from false to true") { waitUntil { done in
-                        loginVM.passwordVisible.signal.take(1).observeNext {
+                        loginViewModel.passwordVisible.signal.take(1).observeNext {
                             expect($0) == true
                             done()
                         }
-                        loginVM.togglePasswordVisibility.execute("")
+                        loginViewModel.togglePasswordVisibility.execute("")
                     }}
                     
                     it("should change #passwordVisible from true to false") { waitUntil { done in
-                        loginVM.passwordVisible.signal.take(2).skip(1).observeNext {
+                        loginViewModel.passwordVisible.signal.take(2).skip(1).observeNext {
                             expect($0) == false
                             done()
                         }
-                        loginVM.togglePasswordVisibility.execute("")
-                        loginVM.togglePasswordVisibility.execute("")
+                        loginViewModel.togglePasswordVisibility.execute("")
+                        loginViewModel.togglePasswordVisibility.execute("")
                     }}
                     
                 }
@@ -66,19 +66,19 @@ class LoginViewModelSpec: QuickSpec {
                 context("when email doesn't have @ character") {
                     
                     beforeEach() {
-                        loginVM.email.value = "my"
+                        loginViewModel.email.value = "my"
                     }
                     
                     it("has one email error") {
-                        expect(loginVM.emailValidationErrors.value.count).toEventually(equal(1), timeout: 3)
+                        expect(loginViewModel.emailValidationErrors.value.count).toEventually(equal(1), timeout: 3)
                     }
                     
                     it("has no password errors") {
-                        expect(loginVM.passwordValidationErrors.value) == []
+                        expect(loginViewModel.passwordValidationErrors.value) == []
                     }
                     
                     it("does not let logIn start") {
-                        expect(loginVM.logInCocoaAction.enabled) == false
+                        expect(loginViewModel.logInCocoaAction.enabled) == false
                     }
                     
                 }
@@ -86,20 +86,20 @@ class LoginViewModelSpec: QuickSpec {
                 context("when email is empty") {
                     
                     beforeEach() {
-                        loginVM.email.value = "my"
-                        loginVM.email.value = ""
+                        loginViewModel.email.value = "my"
+                        loginViewModel.email.value = ""
                     }
                     
                     it("has two email error - empty and not valid") {
-                        expect(loginVM.emailValidationErrors.value.count).toEventually(equal(2), timeout: 3)
+                        expect(loginViewModel.emailValidationErrors.value.count).toEventually(equal(2), timeout: 3)
                     }
                     
                     it("has no password errors") {
-                        expect(loginVM.passwordValidationErrors.value) == []
+                        expect(loginViewModel.passwordValidationErrors.value) == []
                     }
                     
                     it("does not let logIn start") {
-                        expect(loginVM.logInCocoaAction.enabled) == false
+                        expect(loginViewModel.logInCocoaAction.enabled) == false
                     }
                     
                 }
@@ -112,19 +112,19 @@ class LoginViewModelSpec: QuickSpec {
                 context("when password is shorter than expected") {
                     
                     beforeEach() {
-                        loginVM.password.value = "my"
+                        loginViewModel.password.value = "my"
                     }
                     
                     it("has one password error") {
-                        expect(loginVM.passwordValidationErrors.value.count).toEventually(equal(1), timeout: 3)
+                        expect(loginViewModel.passwordValidationErrors.value.count).toEventually(equal(1), timeout: 3)
                     }
                     
                     it("has no email errors") {
-                        expect(loginVM.emailValidationErrors.value) == []
+                        expect(loginViewModel.emailValidationErrors.value) == []
                     }
                     
                     it("does not let logIn start") {
-                        expect(loginVM.logInCocoaAction.enabled) == false
+                        expect(loginViewModel.logInCocoaAction.enabled) == false
                     }
                     
                 }
@@ -132,19 +132,19 @@ class LoginViewModelSpec: QuickSpec {
                 context("when password is longer than expected") {
                     
                     beforeEach() {
-                        loginVM.password.value = "myVeryLongPasswordWithMoreThan30Characters"
+                        loginViewModel.password.value = "myVeryLongPasswordWithMoreThan30Characters"
                     }
                     
                     it("has one password error") {
-                        expect(loginVM.passwordValidationErrors.value.count).toEventually(equal(1), timeout: 3)
+                        expect(loginViewModel.passwordValidationErrors.value.count).toEventually(equal(1), timeout: 3)
                     }
                     
                     it("has no email errors") {
-                        expect(loginVM.emailValidationErrors.value) == []
+                        expect(loginViewModel.emailValidationErrors.value) == []
                     }
                     
                     it("does not let logIn start") {
-                        expect(loginVM.logInCocoaAction.enabled) == false
+                        expect(loginViewModel.logInCocoaAction.enabled) == false
                     }
                     
                 }
@@ -152,20 +152,20 @@ class LoginViewModelSpec: QuickSpec {
                 context("when password is empty") {
                     
                     beforeEach() {
-                        loginVM.password.value = "my"
-                        loginVM.password.value = ""
+                        loginViewModel.password.value = "my"
+                        loginViewModel.password.value = ""
                     }
                     
                     it("has two password errors - empty and short") {
-                        expect(loginVM.passwordValidationErrors.value.count).toEventually(equal(2), timeout: 3)
+                        expect(loginViewModel.passwordValidationErrors.value.count).toEventually(equal(2), timeout: 3)
                     }
                     
                     it("has no email errors") {
-                        expect(loginVM.emailValidationErrors.value) == []
+                        expect(loginViewModel.emailValidationErrors.value) == []
                     }
                     
                     it("does not let logIn start") {
-                        expect(loginVM.logInCocoaAction.enabled) == false
+                        expect(loginViewModel.logInCocoaAction.enabled) == false
                     }
                     
                 }
@@ -177,22 +177,22 @@ class LoginViewModelSpec: QuickSpec {
                 context("when email and password are wrong") {
                     
                     beforeEach() {
-                        loginVM.email.value = "wrong@email.com"
-                        loginVM.password.value = "wrongPassword"
+                        loginViewModel.email.value = "wrong@email.com"
+                        loginViewModel.password.value = "wrongPassword"
                     }
                     
                     it("has no errors at all") {
-                        expect(loginVM.emailValidationErrors.value) == []
-                        expect(loginVM.passwordValidationErrors.value) == []
+                        expect(loginViewModel.emailValidationErrors.value) == []
+                        expect(loginViewModel.passwordValidationErrors.value) == []
                     }
                     
                     it("enables LogIn") {
-                        expect(loginVM.logInCocoaAction.enabled) == true
+                        expect(loginViewModel.logInCocoaAction.enabled) == true
                     }
                     
                     it("calls session service's signup") { waitUntil { done in
                         sessionService.logInCalled.observeNext { _ in done() }
-                        loginVM.logInCocoaAction.execute("")
+                        loginViewModel.logInCocoaAction.execute("")
                     }}
                     
                 }
@@ -200,22 +200,22 @@ class LoginViewModelSpec: QuickSpec {
                 context("when email is correct but password is wrong") {
                     
                     beforeEach() {
-                        loginVM.email.value = "myuser@mail.com"
-                        loginVM.password.value = "wrongPassword"
+                        loginViewModel.email.value = "myuser@mail.com"
+                        loginViewModel.password.value = "wrongPassword"
                     }
                     
                     it("has no errors at all") {
-                        expect(loginVM.emailValidationErrors.value) == []
-                        expect(loginVM.passwordValidationErrors.value) == []
+                        expect(loginViewModel.emailValidationErrors.value) == []
+                        expect(loginViewModel.passwordValidationErrors.value) == []
                     }
                     
                     it("enables LogIn") {
-                        expect(loginVM.logInCocoaAction.enabled) == true
+                        expect(loginViewModel.logInCocoaAction.enabled) == true
                     }
                     
                     it("calls session service's signup") { waitUntil { done in
                         sessionService.logInCalled.observeNext { _ in done() }
-                        loginVM.logInCocoaAction.execute("")
+                        loginViewModel.logInCocoaAction.execute("")
                     }}
                     
                 }
@@ -223,22 +223,22 @@ class LoginViewModelSpec: QuickSpec {
                 context("when email is wrong and password is correct") {
                     
                     beforeEach() {
-                        loginVM.email.value = "wrong@email.com"
-                        loginVM.password.value = "password"
+                        loginViewModel.email.value = "wrong@email.com"
+                        loginViewModel.password.value = "password"
                     }
                     
                     it("has no errors at all") {
-                        expect(loginVM.emailValidationErrors.value) == []
-                        expect(loginVM.passwordValidationErrors.value) == []
+                        expect(loginViewModel.emailValidationErrors.value) == []
+                        expect(loginViewModel.passwordValidationErrors.value) == []
                     }
                     
                     it("enables LogIn") {
-                        expect(loginVM.logInCocoaAction.enabled) == true
+                        expect(loginViewModel.logInCocoaAction.enabled) == true
                     }
                     
                     it("calls session service's signup") { waitUntil { done in
                         sessionService.logInCalled.observeNext { _ in done() }
-                        loginVM.logInCocoaAction.execute("")
+                        loginViewModel.logInCocoaAction.execute("")
                     }}
                     
                 }
@@ -246,22 +246,22 @@ class LoginViewModelSpec: QuickSpec {
                 context("when email and password are correct") {
                     
                     beforeEach() {
-                        loginVM.email.value = "myuser@mail.com"
-                        loginVM.password.value = "password"
+                        loginViewModel.email.value = "myuser@mail.com"
+                        loginViewModel.password.value = "password"
                     }
                     
                     it("has no errors at all") {
-                        expect(loginVM.emailValidationErrors.value) == []
-                        expect(loginVM.passwordValidationErrors.value) == []
+                        expect(loginViewModel.emailValidationErrors.value) == []
+                        expect(loginViewModel.passwordValidationErrors.value) == []
                     }
                     
                     it("enables LogIn") {
-                        expect(loginVM.logInCocoaAction.enabled) == true
+                        expect(loginViewModel.logInCocoaAction.enabled) == true
                     }
                     
                     it("calls session service's signup") { waitUntil { done in
                         sessionService.logInCalled.observeNext { _ in done() }
-                        loginVM.logInCocoaAction.execute("")
+                        loginViewModel.logInCocoaAction.execute("")
                     }}
                     
                 }

--- a/AuthenticationTests/LogIn/LoginViewModelTests.swift
+++ b/AuthenticationTests/LogIn/LoginViewModelTests.swift
@@ -38,22 +38,28 @@ class LoginViewModelSpec: QuickSpec {
             
             describe("#togglePasswordVisibility") {
                 
-                context("when executing action") {
+                context("when #passwordVisible is false") {
                     
-                    it("should change #passwordVisible from false to true") { waitUntil { done in
+                    it("should change it to true") { waitUntil { done in
                         loginViewModel.passwordVisible.signal.take(1).observeNext {
                             expect($0) == true
                             done()
                         }
                         loginViewModel.togglePasswordVisibility.execute("")
                     }}
+                }
+                
+                context("when #passwordVisible is true") {
                     
-                    it("should change #passwordVisible from true to false") { waitUntil { done in
-                        loginViewModel.passwordVisible.signal.take(2).skip(1).observeNext {
+                    beforeEach() {
+                        loginViewModel.togglePasswordVisibility.execute("")
+                    }
+                    
+                    it("should change it to false") { waitUntil { done in
+                        loginViewModel.passwordVisible.signal.take(1).observeNext {
                             expect($0) == false
                             done()
                         }
-                        loginViewModel.togglePasswordVisibility.execute("")
                         loginViewModel.togglePasswordVisibility.execute("")
                     }}
                     

--- a/AuthenticationTests/Mocks/MockLoginTransitionDelegate.swift
+++ b/AuthenticationTests/Mocks/MockLoginTransitionDelegate.swift
@@ -11,12 +11,8 @@ import Authentication
 
 final class MockLoginTransitionDelegate: LoginControllerTransitionDelegate {
     
-    func onSignup(controller: LoginController) {
-        
-    }
+    func onSignup(controller: LoginController) { }
     
-    func onRecoverPassword(controller: LoginController) {
-        
-    }
+    func onRecoverPassword(controller: LoginController) { }
     
 }

--- a/AuthenticationTests/Mocks/MyUser.swift
+++ b/AuthenticationTests/Mocks/MyUser.swift
@@ -10,6 +10,7 @@ import Foundation
 import Authentication
 
 struct MyUser: UserType {
+    
     let email: Email
     let username: String
     let password: String
@@ -19,4 +20,5 @@ struct MyUser: UserType {
         self.username = username
         self.password = password
     }
+    
 }

--- a/AuthenticationTests/Signup/SignupViewModelSpec.swift
+++ b/AuthenticationTests/Signup/SignupViewModelSpec.swift
@@ -1,0 +1,398 @@
+//
+//  SignupViewModelTests.swift
+//  Authentication
+//
+//  Created by Daniela Riesgo on 7/27/16.
+//  Copyright © 2016 Wolox. All rights reserved.
+//
+
+import Quick
+import Nimble
+@testable import Authentication
+
+import ReactiveCocoa
+import enum Result.NoError
+
+
+class SignupViewModelSpec: QuickSpec {
+    
+    override func spec() {
+        describe("SignupViewModel") {
+            
+            let validEmail = "example@mail.com"
+            let validPassword = "password"
+            let invalidPassword = "pass"
+            let validUsername = "username"
+            let invalidUsername = ""
+            
+            var sessionService: MockSessionService!
+            var signupVM: SignupViewModel<MyUser, MockSessionService>!
+            
+            beforeEach() {
+                sessionService = MockSessionService()
+                signupVM = SignupViewModel(sessionService: sessionService, passwordConfirmationEnabled: false, usernameEnabled: false)
+            }
+            
+            it("starts without errors") {
+                expect(signupVM.usernameValidationErrors.value) == []
+                expect(signupVM.emailValidationErrors.value) == []
+                expect(signupVM.passwordValidationErrors.value) == []
+                expect(signupVM.passwordConfirmationValidationErrors.value) == []
+            }
+            
+            it("starts without showing password") {
+                expect(signupVM.passwordVisible.value) == false
+                expect(signupVM.confirmationPasswordVisible.value) == false
+            }
+            
+            context("when username and password confirmation disabled") {
+                
+                context("when filling email with invalid email") {
+                    
+                    context("when email doesn't have @ character") {
+                        
+                        beforeEach() {
+                            signupVM.email.value = "my"
+                        }
+                        
+                        it("has one email error") {
+                            expect(signupVM.emailValidationErrors.value.count).toEventually(equal(1), timeout: 3)
+                        }
+                        
+                        it("has no password errors") {
+                            expect(signupVM.passwordValidationErrors.value) == []
+                        }
+                        
+                        it("does not let signUp start") {
+                            expect(signupVM.signUpCocoaAction.enabled) == false
+                        }
+                        
+                    }
+                    
+                    context("when email is empty") {
+                        
+                        beforeEach() {
+                            signupVM.email.value = "my"
+                            signupVM.email.value = ""
+                        }
+                        
+                        it("has two email error - empty and not valid") {
+                            expect(signupVM.emailValidationErrors.value.count).toEventually(equal(2), timeout: 3)
+                        }
+                        
+                        it("has no password errors") {
+                            expect(signupVM.passwordValidationErrors.value) == []
+                        }
+                        
+                        it("does not let signUp start") {
+                            expect(signupVM.signUpCocoaAction.enabled) == false
+                        }
+                        
+                    }
+                    
+                }
+                
+                context("when filling password with invalid password") {
+                    
+                    context("when password is shorter than expected") {
+                        
+                        beforeEach() {
+                            signupVM.password.value = "my"
+                        }
+                        
+                        it("has one password error") {
+                            expect(signupVM.passwordValidationErrors.value.count).toEventually(equal(1), timeout: 3)
+                        }
+                        
+                        it("has no email errors") {
+                            expect(signupVM.emailValidationErrors.value) == []
+                        }
+                        
+                        it("does not let signUp start") {
+                            expect(signupVM.signUpCocoaAction.enabled) == false
+                        }
+                        
+                    }
+                    
+                    context("when password is longer than expected") {
+                        
+                        beforeEach() {
+                            signupVM.password.value = "myVeryLongPasswordWithMoreThan30Characters"
+                        }
+                        
+                        it("has one password error") {
+                            expect(signupVM.passwordValidationErrors.value.count).toEventually(equal(1), timeout: 3)
+                        }
+                        
+                        it("has no email errors") {
+                            expect(signupVM.emailValidationErrors.value) == []
+                        }
+                        
+                        it("does not let signUp start") {
+                            expect(signupVM.signUpCocoaAction.enabled) == false
+                        }
+                        
+                    }
+                    
+                    context("when password is empty") {
+                        
+                        beforeEach() {
+                            signupVM.password.value = "my"
+                            signupVM.password.value = ""
+                        }
+                        
+                        it("has two password errors - empty and short") {
+                            expect(signupVM.passwordValidationErrors.value.count).toEventually(equal(2), timeout: 3)
+                        }
+                        
+                        it("has no email errors") {
+                            expect(signupVM.emailValidationErrors.value) == []
+                        }
+                        
+                        it("does not let signUp start") {
+                            expect(signupVM.signUpCocoaAction.enabled) == false
+                        }
+                        
+                    }
+                    
+                }
+                
+                context("when filling with valid email and password") {
+                    
+                    beforeEach() {
+                        signupVM.email.value = validEmail
+                        signupVM.password.value = validPassword
+                    }
+                    
+                    it("has no errors at all") {
+                        expect(signupVM.emailValidationErrors.value) == []
+                        expect(signupVM.passwordValidationErrors.value) == []
+                    }
+                    
+                    it("enables signUp") {
+                        expect(signupVM.signUpCocoaAction.enabled) == true
+                    }
+                    
+                    it("calls session service's signup") { waitUntil { done in
+                        sessionService.signUpCalled.observeNext { _ in done() }
+                        signupVM.signUpCocoaAction.execute("")
+                        }}
+                    
+                }
+            }
+            
+            context("when username enabled and password confirmation disabled") {
+                
+                beforeEach() {
+                    signupVM = SignupViewModel(sessionService: sessionService, passwordConfirmationEnabled: false, usernameEnabled: true)
+                }
+                
+                context("when email and password are valid") {
+                    
+                    beforeEach() {
+                        signupVM.email.value = validEmail
+                        signupVM.password.value = validPassword
+                    }
+                    
+                    context("when username is valid") {
+                        
+                        beforeEach() {
+                            signupVM.username.value = validUsername
+                        }
+                        
+                        it("has no errors at all") {
+                            expect(signupVM.usernameValidationErrors.value) == []
+                        }
+                        
+                        it("enables signUp") {
+                            expect(signupVM.signUpCocoaAction.enabled) == true
+                        }
+                        
+                        it("calls session service's signup") { waitUntil { done in
+                            sessionService.signUpCalled.observeNext { _ in done() }
+                            signupVM.signUpCocoaAction.execute("")
+                            }}
+                        
+                    }
+                    
+                    context("when username is invalid") {
+                        
+                        beforeEach() {
+                            signupVM.username.value = invalidUsername
+                        }
+                        
+                        it("has one username error - empty") {
+                            expect(signupVM.usernameValidationErrors.value.count).toEventually(equal(1), timeout: 3)
+                        }
+                        
+                        it("does not let signUp start") {
+                            expect(signupVM.signUpCocoaAction.enabled) == false
+                        }
+                        
+                    }
+                    
+                }
+                
+            }
+            
+            context("when password confirmation enabled and username disabled") {
+                
+                beforeEach() {
+                    signupVM = SignupViewModel(sessionService: sessionService, passwordConfirmationEnabled: true, usernameEnabled: false)
+                }
+                
+                context("when email and password valid") {
+                    
+                    beforeEach() {
+                        signupVM.email.value = validEmail
+                        signupVM.password.value = validPassword
+                    }
+                    
+                    context("when password confirmation is valid") {
+                        
+                        beforeEach() {
+                            signupVM.passwordConfirmation.value = validPassword
+                        }
+                        
+                        it("has no errors at all") {
+                            expect(signupVM.passwordConfirmationValidationErrors.value) == []
+                        }
+                        
+                        it("enables signUp") {
+                            expect(signupVM.signUpCocoaAction.enabled) == true
+                        }
+                        
+                        it("calls session service's signup") { waitUntil { done in
+                            sessionService.signUpCalled.observeNext { _ in done() }
+                            signupVM.signUpCocoaAction.execute("")
+                            }}
+                        
+                    }
+                    
+                    context("when password confirmation is invalid") {
+                        
+                        beforeEach() {
+                            signupVM.passwordConfirmation.value = invalidPassword
+                        }
+                        
+                        it("has one password confirmation error - not matching") {
+                            expect(signupVM.passwordConfirmationValidationErrors.value.count).toEventually(equal(1), timeout: 3)
+                        }
+                        
+                        it("does not let signUp start") {
+                            expect(signupVM.signUpCocoaAction.enabled) == false
+                        }
+                        
+                    }
+                    
+                }
+                
+            }
+            
+            context("when username and password confirmation enabled") {
+                
+                beforeEach() {
+                    signupVM = SignupViewModel(sessionService: sessionService, passwordConfirmationEnabled: true, usernameEnabled: true)
+                }
+                
+                context("when email and password valid") {
+                    
+                    beforeEach() {
+                        signupVM.email.value = "myuser@mail.com"
+                        signupVM.password.value = "password"
+                    }
+                    
+                    context("when username invalid and password confirmation valid") {
+                        
+                        beforeEach() {
+                            signupVM.username.value = ""
+                            signupVM.passwordConfirmation.value = "password"
+                        }
+                        
+                        it("has one username error - empty") {
+                            expect(signupVM.usernameValidationErrors.value.count).toEventually(equal(1), timeout: 3)
+                        }
+                        
+                        it("has no password confirmation errors") {
+                            expect(signupVM.passwordConfirmationValidationErrors.value) == []
+                        }
+                        
+                        it("does not let signUp start") {
+                            expect(signupVM.signUpCocoaAction.enabled) == false
+                        }
+                        
+                    }
+                    
+                    context("when username valid and password confirmation invalid") {
+                        
+                        beforeEach() {
+                            signupVM.username.value = "username"
+                            signupVM.passwordConfirmation.value = "pass"
+                        }
+                        
+                        it("has one password confirmation error - empty") {
+                            expect(signupVM.passwordConfirmationValidationErrors.value.count).toEventually(equal(1), timeout: 3)
+                        }
+                        
+                        it("has no username errors") {
+                            expect(signupVM.usernameValidationErrors.value) == []
+                        }
+                        
+                        it("does not let signUp start") {
+                            expect(signupVM.signUpCocoaAction.enabled) == false
+                        }
+                        
+                    }
+                    
+                    context("when username and password confirmation invalid") {
+                        
+                        beforeEach() {
+                            signupVM.username.value = ""
+                            signupVM.passwordConfirmation.value = "pass"
+                        }
+                        
+                        it("has one username error - empty") {
+                            expect(signupVM.usernameValidationErrors.value.count).toEventually(equal(1), timeout: 3)
+                        }
+                        
+                        it("has one password confirmation error - empty") {
+                            expect(signupVM.passwordConfirmationValidationErrors.value.count).toEventually(equal(1), timeout: 3)
+                        }
+                        
+                        it("does not let signUp start") {
+                            expect(signupVM.signUpCocoaAction.enabled) == false
+                        }
+                        
+                    }
+                    
+                    context("when username and password confirmation valid") {
+                        
+                        beforeEach() {
+                            signupVM.username.value = "username"
+                            signupVM.passwordConfirmation.value = "password"
+                        }
+                        
+                        it("has no errors at all") {
+                            expect(signupVM.usernameValidationErrors.value) == []
+                            expect(signupVM.passwordConfirmationValidationErrors.value) == []
+                        }
+                        
+                        it("enables signUp") {
+                            expect(signupVM.signUpCocoaAction.enabled) == true
+                        }
+                        
+                        it("calls session service's signup") { waitUntil { done in
+                            sessionService.signUpCalled.observeNext { _ in done() }
+                            signupVM.signUpCocoaAction.execute("")
+                            }}
+                        
+                    }
+                    
+                }
+                
+            }
+            
+        }
+    }
+    
+}

--- a/AuthenticationTests/Signup/SignupViewModelSpec.swift
+++ b/AuthenticationTests/Signup/SignupViewModelSpec.swift
@@ -42,7 +42,7 @@ class SignupViewModelSpec: QuickSpec {
             
             it("starts without showing password") {
                 expect(signupVM.passwordVisible.value) == false
-                expect(signupVM.confirmationPasswordVisible.value) == false
+                expect(signupVM.passwordConfirmationVisible.value) == false
             }
             
             context("when username and password confirmation disabled") {

--- a/AuthenticationTests/Signup/SignupViewModelTests.swift
+++ b/AuthenticationTests/Signup/SignupViewModelTests.swift
@@ -26,23 +26,23 @@ class SignupViewModelSpec: QuickSpec {
             let invalidUsername = ""
             
             var sessionService: MockSessionService!
-            var signupVM: SignupViewModel<MyUser, MockSessionService>!
+            var signupViewModel: SignupViewModel<MyUser, MockSessionService>!
             
             beforeEach() {
                 sessionService = MockSessionService()
-                signupVM = SignupViewModel(sessionService: sessionService, passwordConfirmationEnabled: false, usernameEnabled: false)
+                signupViewModel = SignupViewModel(sessionService: sessionService, passwordConfirmationEnabled: false, usernameEnabled: false)
             }
             
             it("starts without errors") {
-                expect(signupVM.usernameValidationErrors.value) == []
-                expect(signupVM.emailValidationErrors.value) == []
-                expect(signupVM.passwordValidationErrors.value) == []
-                expect(signupVM.passwordConfirmationValidationErrors.value) == []
+                expect(signupViewModel.usernameValidationErrors.value) == []
+                expect(signupViewModel.emailValidationErrors.value) == []
+                expect(signupViewModel.passwordValidationErrors.value) == []
+                expect(signupViewModel.passwordConfirmationValidationErrors.value) == []
             }
             
             it("starts without showing password") {
-                expect(signupVM.passwordVisible.value) == false
-                expect(signupVM.passwordConfirmationVisible.value) == false
+                expect(signupViewModel.passwordVisible.value) == false
+                expect(signupViewModel.passwordConfirmationVisible.value) == false
             }
             
             describe("#togglePasswordVisibility") {
@@ -50,20 +50,20 @@ class SignupViewModelSpec: QuickSpec {
                 context("when executing action") {
                     
                     it("should change #passwordVisible from false to true") { waitUntil { done in
-                        signupVM.passwordVisible.signal.take(1).observeNext {
+                        signupViewModel.passwordVisible.signal.take(1).observeNext {
                             expect($0) == true
                             done()
                         }
-                        signupVM.togglePasswordVisibility.execute("")
+                        signupViewModel.togglePasswordVisibility.execute("")
                     }}
                     
                     it("should change #passwordVisible from true to false") { waitUntil { done in
-                        signupVM.passwordVisible.signal.take(2).skip(1).observeNext {
+                        signupViewModel.passwordVisible.signal.take(2).skip(1).observeNext {
                             expect($0) == false
                             done()
                         }
-                        signupVM.togglePasswordVisibility.execute("")
-                        signupVM.togglePasswordVisibility.execute("")
+                        signupViewModel.togglePasswordVisibility.execute("")
+                        signupViewModel.togglePasswordVisibility.execute("")
                     }}
                     
                 }
@@ -75,20 +75,20 @@ class SignupViewModelSpec: QuickSpec {
                 context("when executing action") {
                     
                     it("should change #passwordConfirmationVisible from false to true") { waitUntil { done in
-                        signupVM.passwordConfirmationVisible.signal.take(1).observeNext {
+                        signupViewModel.passwordConfirmationVisible.signal.take(1).observeNext {
                             expect($0) == true
                             done()
                         }
-                        signupVM.togglePasswordConfirmVisibility.execute("")
+                        signupViewModel.togglePasswordConfirmVisibility.execute("")
                     }}
                     
                     it("should change #passwordConfirmationVisible from true to false") { waitUntil { done in
-                        signupVM.passwordConfirmationVisible.signal.take(2).skip(1).observeNext {
+                        signupViewModel.passwordConfirmationVisible.signal.take(2).skip(1).observeNext {
                             expect($0) == false
                             done()
                         }
-                        signupVM.togglePasswordConfirmVisibility.execute("")
-                        signupVM.togglePasswordConfirmVisibility.execute("")
+                        signupViewModel.togglePasswordConfirmVisibility.execute("")
+                        signupViewModel.togglePasswordConfirmVisibility.execute("")
                     }}
                     
                 }
@@ -102,19 +102,19 @@ class SignupViewModelSpec: QuickSpec {
                     context("when email doesn't have @ character") {
                         
                         beforeEach() {
-                            signupVM.email.value = "my"
+                            signupViewModel.email.value = "my"
                         }
                         
                         it("has one email error") {
-                            expect(signupVM.emailValidationErrors.value.count).toEventually(equal(1), timeout: 3)
+                            expect(signupViewModel.emailValidationErrors.value.count).toEventually(equal(1), timeout: 3)
                         }
                         
                         it("has no password errors") {
-                            expect(signupVM.passwordValidationErrors.value) == []
+                            expect(signupViewModel.passwordValidationErrors.value) == []
                         }
                         
                         it("does not let signUp start") {
-                            expect(signupVM.signUpCocoaAction.enabled) == false
+                            expect(signupViewModel.signUpCocoaAction.enabled) == false
                         }
                         
                     }
@@ -122,20 +122,20 @@ class SignupViewModelSpec: QuickSpec {
                     context("when email is empty") {
                         
                         beforeEach() {
-                            signupVM.email.value = "my"
-                            signupVM.email.value = ""
+                            signupViewModel.email.value = "my"
+                            signupViewModel.email.value = ""
                         }
                         
                         it("has two email error - empty and not valid") {
-                            expect(signupVM.emailValidationErrors.value.count).toEventually(equal(2), timeout: 3)
+                            expect(signupViewModel.emailValidationErrors.value.count).toEventually(equal(2), timeout: 3)
                         }
                         
                         it("has no password errors") {
-                            expect(signupVM.passwordValidationErrors.value) == []
+                            expect(signupViewModel.passwordValidationErrors.value) == []
                         }
                         
                         it("does not let signUp start") {
-                            expect(signupVM.signUpCocoaAction.enabled) == false
+                            expect(signupViewModel.signUpCocoaAction.enabled) == false
                         }
                         
                     }
@@ -147,19 +147,19 @@ class SignupViewModelSpec: QuickSpec {
                     context("when password is shorter than expected") {
                         
                         beforeEach() {
-                            signupVM.password.value = "my"
+                            signupViewModel.password.value = "my"
                         }
                         
                         it("has one password error") {
-                            expect(signupVM.passwordValidationErrors.value.count).toEventually(equal(1), timeout: 3)
+                            expect(signupViewModel.passwordValidationErrors.value.count).toEventually(equal(1), timeout: 3)
                         }
                         
                         it("has no email errors") {
-                            expect(signupVM.emailValidationErrors.value) == []
+                            expect(signupViewModel.emailValidationErrors.value) == []
                         }
                         
                         it("does not let signUp start") {
-                            expect(signupVM.signUpCocoaAction.enabled) == false
+                            expect(signupViewModel.signUpCocoaAction.enabled) == false
                         }
                         
                     }
@@ -167,19 +167,19 @@ class SignupViewModelSpec: QuickSpec {
                     context("when password is longer than expected") {
                         
                         beforeEach() {
-                            signupVM.password.value = "myVeryLongPasswordWithMoreThan30Characters"
+                            signupViewModel.password.value = "myVeryLongPasswordWithMoreThan30Characters"
                         }
                         
                         it("has one password error") {
-                            expect(signupVM.passwordValidationErrors.value.count).toEventually(equal(1), timeout: 3)
+                            expect(signupViewModel.passwordValidationErrors.value.count).toEventually(equal(1), timeout: 3)
                         }
                         
                         it("has no email errors") {
-                            expect(signupVM.emailValidationErrors.value) == []
+                            expect(signupViewModel.emailValidationErrors.value) == []
                         }
                         
                         it("does not let signUp start") {
-                            expect(signupVM.signUpCocoaAction.enabled) == false
+                            expect(signupViewModel.signUpCocoaAction.enabled) == false
                         }
                         
                     }
@@ -187,20 +187,20 @@ class SignupViewModelSpec: QuickSpec {
                     context("when password is empty") {
                         
                         beforeEach() {
-                            signupVM.password.value = "my"
-                            signupVM.password.value = ""
+                            signupViewModel.password.value = "my"
+                            signupViewModel.password.value = ""
                         }
                         
                         it("has two password errors - empty and short") {
-                            expect(signupVM.passwordValidationErrors.value.count).toEventually(equal(2), timeout: 3)
+                            expect(signupViewModel.passwordValidationErrors.value.count).toEventually(equal(2), timeout: 3)
                         }
                         
                         it("has no email errors") {
-                            expect(signupVM.emailValidationErrors.value) == []
+                            expect(signupViewModel.emailValidationErrors.value) == []
                         }
                         
                         it("does not let signUp start") {
-                            expect(signupVM.signUpCocoaAction.enabled) == false
+                            expect(signupViewModel.signUpCocoaAction.enabled) == false
                         }
                         
                     }
@@ -210,22 +210,22 @@ class SignupViewModelSpec: QuickSpec {
                 context("when filling with valid email and password") {
                     
                     beforeEach() {
-                        signupVM.email.value = validEmail
-                        signupVM.password.value = validPassword
+                        signupViewModel.email.value = validEmail
+                        signupViewModel.password.value = validPassword
                     }
                     
                     it("has no errors at all") {
-                        expect(signupVM.emailValidationErrors.value) == []
-                        expect(signupVM.passwordValidationErrors.value) == []
+                        expect(signupViewModel.emailValidationErrors.value) == []
+                        expect(signupViewModel.passwordValidationErrors.value) == []
                     }
                     
                     it("enables signUp") {
-                        expect(signupVM.signUpCocoaAction.enabled) == true
+                        expect(signupViewModel.signUpCocoaAction.enabled) == true
                     }
                     
                     it("calls session service's signup") { waitUntil { done in
                         sessionService.signUpCalled.take(1).observeNext { _ in done() }
-                        signupVM.signUpCocoaAction.execute("")
+                        signupViewModel.signUpCocoaAction.execute("")
                     }}
                     
                 }
@@ -234,33 +234,33 @@ class SignupViewModelSpec: QuickSpec {
             context("when username enabled and password confirmation disabled") {
                 
                 beforeEach() {
-                    signupVM = SignupViewModel(sessionService: sessionService, passwordConfirmationEnabled: false, usernameEnabled: true)
+                    signupViewModel = SignupViewModel(sessionService: sessionService, passwordConfirmationEnabled: false, usernameEnabled: true)
                 }
                 
                 context("when email and password are valid") {
                     
                     beforeEach() {
-                        signupVM.email.value = validEmail
-                        signupVM.password.value = validPassword
+                        signupViewModel.email.value = validEmail
+                        signupViewModel.password.value = validPassword
                     }
                     
                     context("when username is valid") {
                         
                         beforeEach() {
-                            signupVM.username.value = validUsername
+                            signupViewModel.username.value = validUsername
                         }
                         
                         it("has no errors at all") {
-                            expect(signupVM.usernameValidationErrors.value) == []
+                            expect(signupViewModel.usernameValidationErrors.value) == []
                         }
                         
                         it("enables signUp") {
-                            expect(signupVM.signUpCocoaAction.enabled) == true
+                            expect(signupViewModel.signUpCocoaAction.enabled) == true
                         }
                         
                         it("calls session service's signup") { waitUntil { done in
                             sessionService.signUpCalled.take(1).observeNext { _ in done() }
-                            signupVM.signUpCocoaAction.execute("")
+                            signupViewModel.signUpCocoaAction.execute("")
                         }}
                         
                     }
@@ -268,15 +268,15 @@ class SignupViewModelSpec: QuickSpec {
                     context("when username is invalid") {
                         
                         beforeEach() {
-                            signupVM.username.value = invalidUsername
+                            signupViewModel.username.value = invalidUsername
                         }
                         
                         it("has one username error - empty") {
-                            expect(signupVM.usernameValidationErrors.value.count).toEventually(equal(1), timeout: 3)
+                            expect(signupViewModel.usernameValidationErrors.value.count).toEventually(equal(1), timeout: 3)
                         }
                         
                         it("does not let signUp start") {
-                            expect(signupVM.signUpCocoaAction.enabled) == false
+                            expect(signupViewModel.signUpCocoaAction.enabled) == false
                         }
                         
                     }
@@ -288,33 +288,33 @@ class SignupViewModelSpec: QuickSpec {
             context("when password confirmation enabled and username disabled") {
                 
                 beforeEach() {
-                    signupVM = SignupViewModel(sessionService: sessionService, passwordConfirmationEnabled: true, usernameEnabled: false)
+                    signupViewModel = SignupViewModel(sessionService: sessionService, passwordConfirmationEnabled: true, usernameEnabled: false)
                 }
                 
                 context("when email and password valid") {
                     
                     beforeEach() {
-                        signupVM.email.value = validEmail
-                        signupVM.password.value = validPassword
+                        signupViewModel.email.value = validEmail
+                        signupViewModel.password.value = validPassword
                     }
                     
                     context("when password confirmation is valid") {
                         
                         beforeEach() {
-                            signupVM.passwordConfirmation.value = validPassword
+                            signupViewModel.passwordConfirmation.value = validPassword
                         }
                         
                         it("has no errors at all") {
-                            expect(signupVM.passwordConfirmationValidationErrors.value) == []
+                            expect(signupViewModel.passwordConfirmationValidationErrors.value) == []
                         }
                         
                         it("enables signUp") {
-                            expect(signupVM.signUpCocoaAction.enabled) == true
+                            expect(signupViewModel.signUpCocoaAction.enabled) == true
                         }
                         
                         it("calls session service's signup") { waitUntil { done in
                             sessionService.signUpCalled.take(1).observeNext { _ in done() }
-                            signupVM.signUpCocoaAction.execute("")
+                            signupViewModel.signUpCocoaAction.execute("")
                         }}
                         
                     }
@@ -322,15 +322,15 @@ class SignupViewModelSpec: QuickSpec {
                     context("when password confirmation is invalid") {
                         
                         beforeEach() {
-                            signupVM.passwordConfirmation.value = invalidPassword
+                            signupViewModel.passwordConfirmation.value = invalidPassword
                         }
                         
                         it("has one password confirmation error - not matching") {
-                            expect(signupVM.passwordConfirmationValidationErrors.value.count).toEventually(equal(1), timeout: 3)
+                            expect(signupViewModel.passwordConfirmationValidationErrors.value.count).toEventually(equal(1), timeout: 3)
                         }
                         
                         it("does not let signUp start") {
-                            expect(signupVM.signUpCocoaAction.enabled) == false
+                            expect(signupViewModel.signUpCocoaAction.enabled) == false
                         }
                         
                     }
@@ -342,33 +342,33 @@ class SignupViewModelSpec: QuickSpec {
             context("when username and password confirmation enabled") {
                 
                 beforeEach() {
-                    signupVM = SignupViewModel(sessionService: sessionService, passwordConfirmationEnabled: true, usernameEnabled: true)
+                    signupViewModel = SignupViewModel(sessionService: sessionService, passwordConfirmationEnabled: true, usernameEnabled: true)
                 }
                 
                 context("when email and password valid") {
                     
                     beforeEach() {
-                        signupVM.email.value = "myuser@mail.com"
-                        signupVM.password.value = "password"
+                        signupViewModel.email.value = "myuser@mail.com"
+                        signupViewModel.password.value = "password"
                     }
                     
                     context("when username invalid and password confirmation valid") {
                         
                         beforeEach() {
-                            signupVM.username.value = ""
-                            signupVM.passwordConfirmation.value = "password"
+                            signupViewModel.username.value = ""
+                            signupViewModel.passwordConfirmation.value = "password"
                         }
                         
                         it("has one username error - empty") {
-                            expect(signupVM.usernameValidationErrors.value.count).toEventually(equal(1), timeout: 3)
+                            expect(signupViewModel.usernameValidationErrors.value.count).toEventually(equal(1), timeout: 3)
                         }
                         
                         it("has no password confirmation errors") {
-                            expect(signupVM.passwordConfirmationValidationErrors.value) == []
+                            expect(signupViewModel.passwordConfirmationValidationErrors.value) == []
                         }
                         
                         it("does not let signUp start") {
-                            expect(signupVM.signUpCocoaAction.enabled) == false
+                            expect(signupViewModel.signUpCocoaAction.enabled) == false
                         }
                         
                     }
@@ -376,20 +376,20 @@ class SignupViewModelSpec: QuickSpec {
                     context("when username valid and password confirmation invalid") {
                         
                         beforeEach() {
-                            signupVM.username.value = "username"
-                            signupVM.passwordConfirmation.value = "pass"
+                            signupViewModel.username.value = "username"
+                            signupViewModel.passwordConfirmation.value = "pass"
                         }
                         
                         it("has one password confirmation error - empty") {
-                            expect(signupVM.passwordConfirmationValidationErrors.value.count).toEventually(equal(1), timeout: 3)
+                            expect(signupViewModel.passwordConfirmationValidationErrors.value.count).toEventually(equal(1), timeout: 3)
                         }
                         
-                        it("has no username errors") {
-                            expect(signupVM.usernameValidationErrors.value) == []
+                        it("has no name errors") {
+                            expect(signupViewModel.usernameValidationErrors.value) == []
                         }
                         
                         it("does not let signUp start") {
-                            expect(signupVM.signUpCocoaAction.enabled) == false
+                            expect(signupViewModel.signUpCocoaAction.enabled) == false
                         }
                         
                     }
@@ -397,20 +397,20 @@ class SignupViewModelSpec: QuickSpec {
                     context("when username and password confirmation invalid") {
                         
                         beforeEach() {
-                            signupVM.username.value = ""
-                            signupVM.passwordConfirmation.value = "pass"
+                            signupViewModel.username.value = ""
+                            signupViewModel.passwordConfirmation.value = "pass"
                         }
                         
                         it("has one username error - empty") {
-                            expect(signupVM.usernameValidationErrors.value.count).toEventually(equal(1), timeout: 3)
+                            expect(signupViewModel.usernameValidationErrors.value.count).toEventually(equal(1), timeout: 3)
                         }
                         
                         it("has one password confirmation error - empty") {
-                            expect(signupVM.passwordConfirmationValidationErrors.value.count).toEventually(equal(1), timeout: 3)
+                            expect(signupViewModel.passwordConfirmationValidationErrors.value.count).toEventually(equal(1), timeout: 3)
                         }
                         
                         it("does not let signUp start") {
-                            expect(signupVM.signUpCocoaAction.enabled) == false
+                            expect(signupViewModel.signUpCocoaAction.enabled) == false
                         }
                         
                     }
@@ -418,22 +418,22 @@ class SignupViewModelSpec: QuickSpec {
                     context("when username and password confirmation valid") {
                         
                         beforeEach() {
-                            signupVM.username.value = "username"
-                            signupVM.passwordConfirmation.value = "password"
+                            signupViewModel.username.value = "username"
+                            signupViewModel.passwordConfirmation.value = "password"
                         }
                         
                         it("has no errors at all") {
-                            expect(signupVM.usernameValidationErrors.value) == []
-                            expect(signupVM.passwordConfirmationValidationErrors.value) == []
+                            expect(signupViewModel.usernameValidationErrors.value) == []
+                            expect(signupViewModel.passwordConfirmationValidationErrors.value) == []
                         }
                         
                         it("enables signUp") {
-                            expect(signupVM.signUpCocoaAction.enabled) == true
+                            expect(signupViewModel.signUpCocoaAction.enabled) == true
                         }
                         
                         it("calls session service's signup") { waitUntil { done in
                             sessionService.signUpCalled.take(1).observeNext { _ in done() }
-                            signupVM.signUpCocoaAction.execute("")
+                            signupViewModel.signUpCocoaAction.execute("")
                         }}
                         
                     }

--- a/AuthenticationTests/Signup/SignupViewModelTests.swift
+++ b/AuthenticationTests/Signup/SignupViewModelTests.swift
@@ -45,6 +45,56 @@ class SignupViewModelSpec: QuickSpec {
                 expect(signupVM.passwordConfirmationVisible.value) == false
             }
             
+            describe("#togglePasswordVisibility") {
+                
+                context("when executing action") {
+                    
+                    it("should change #passwordVisible from false to true") { waitUntil { done in
+                        signupVM.passwordVisible.signal.take(1).observeNext {
+                            expect($0) == true
+                            done()
+                        }
+                        signupVM.togglePasswordVisibility.execute("")
+                    }}
+                    
+                    it("should change #passwordVisible from true to false") { waitUntil { done in
+                        signupVM.passwordVisible.signal.take(2).skip(1).observeNext {
+                            expect($0) == false
+                            done()
+                        }
+                        signupVM.togglePasswordVisibility.execute("")
+                        signupVM.togglePasswordVisibility.execute("")
+                    }}
+                    
+                }
+                
+            }
+            
+            describe("#togglePasswordConfirmVisibility") {
+                
+                context("when executing action") {
+                    
+                    it("should change #passwordConfirmationVisible from false to true") { waitUntil { done in
+                        signupVM.passwordConfirmationVisible.signal.take(1).observeNext {
+                            expect($0) == true
+                            done()
+                        }
+                        signupVM.togglePasswordConfirmVisibility.execute("")
+                    }}
+                    
+                    it("should change #passwordConfirmationVisible from true to false") { waitUntil { done in
+                        signupVM.passwordConfirmationVisible.signal.take(2).skip(1).observeNext {
+                            expect($0) == false
+                            done()
+                        }
+                        signupVM.togglePasswordConfirmVisibility.execute("")
+                        signupVM.togglePasswordConfirmVisibility.execute("")
+                    }}
+                    
+                }
+                
+            }
+            
             context("when username and password confirmation disabled") {
                 
                 context("when filling email with invalid email") {
@@ -174,9 +224,9 @@ class SignupViewModelSpec: QuickSpec {
                     }
                     
                     it("calls session service's signup") { waitUntil { done in
-                        sessionService.signUpCalled.observeNext { _ in done() }
+                        sessionService.signUpCalled.take(1).observeNext { _ in done() }
                         signupVM.signUpCocoaAction.execute("")
-                        }}
+                    }}
                     
                 }
             }
@@ -209,9 +259,9 @@ class SignupViewModelSpec: QuickSpec {
                         }
                         
                         it("calls session service's signup") { waitUntil { done in
-                            sessionService.signUpCalled.observeNext { _ in done() }
+                            sessionService.signUpCalled.take(1).observeNext { _ in done() }
                             signupVM.signUpCocoaAction.execute("")
-                            }}
+                        }}
                         
                     }
                     
@@ -263,9 +313,9 @@ class SignupViewModelSpec: QuickSpec {
                         }
                         
                         it("calls session service's signup") { waitUntil { done in
-                            sessionService.signUpCalled.observeNext { _ in done() }
+                            sessionService.signUpCalled.take(1).observeNext { _ in done() }
                             signupVM.signUpCocoaAction.execute("")
-                            }}
+                        }}
                         
                     }
                     
@@ -382,9 +432,9 @@ class SignupViewModelSpec: QuickSpec {
                         }
                         
                         it("calls session service's signup") { waitUntil { done in
-                            sessionService.signUpCalled.observeNext { _ in done() }
+                            sessionService.signUpCalled.take(1).observeNext { _ in done() }
                             signupVM.signUpCocoaAction.execute("")
-                            }}
+                        }}
                         
                     }
                     

--- a/AuthenticationTests/Signup/SignupViewModelTests.swift
+++ b/AuthenticationTests/Signup/SignupViewModelTests.swift
@@ -47,22 +47,28 @@ class SignupViewModelSpec: QuickSpec {
             
             describe("#togglePasswordVisibility") {
                 
-                context("when executing action") {
+                context("when #passwordVisible is false") {
                     
-                    it("should change #passwordVisible from false to true") { waitUntil { done in
+                    it("should change it to true") { waitUntil { done in
                         signupViewModel.passwordVisible.signal.take(1).observeNext {
                             expect($0) == true
                             done()
                         }
                         signupViewModel.togglePasswordVisibility.execute("")
                     }}
+                }
+                
+                context("when #passwordVisible is true") {
                     
-                    it("should change #passwordVisible from true to false") { waitUntil { done in
-                        signupViewModel.passwordVisible.signal.take(2).skip(1).observeNext {
+                    beforeEach() {
+                        signupViewModel.togglePasswordVisibility.execute("")
+                    }
+                    
+                    it("should change it to false") { waitUntil { done in
+                        signupViewModel.passwordVisible.signal.take(1).observeNext {
                             expect($0) == false
                             done()
                         }
-                        signupViewModel.togglePasswordVisibility.execute("")
                         signupViewModel.togglePasswordVisibility.execute("")
                     }}
                     
@@ -72,22 +78,28 @@ class SignupViewModelSpec: QuickSpec {
             
             describe("#togglePasswordConfirmVisibility") {
                 
-                context("when executing action") {
+                context("when #passwordVisible is false") {
                     
-                    it("should change #passwordConfirmationVisible from false to true") { waitUntil { done in
+                    it("should change it to true") { waitUntil { done in
                         signupViewModel.passwordConfirmationVisible.signal.take(1).observeNext {
                             expect($0) == true
                             done()
                         }
                         signupViewModel.togglePasswordConfirmVisibility.execute("")
                     }}
+                }
+                
+                context("when #passwordVisible is true") {
                     
-                    it("should change #passwordConfirmationVisible from true to false") { waitUntil { done in
-                        signupViewModel.passwordConfirmationVisible.signal.take(2).skip(1).observeNext {
+                    beforeEach() {
+                        signupViewModel.togglePasswordConfirmVisibility.execute("")
+                    }
+                    
+                    it("should change it to false") { waitUntil { done in
+                        signupViewModel.passwordConfirmationVisible.signal.take(1).observeNext {
                             expect($0) == false
                             done()
                         }
-                        signupViewModel.togglePasswordConfirmVisibility.execute("")
                         signupViewModel.togglePasswordConfirmVisibility.execute("")
                     }}
                     


### PR DESCRIPTION
## Sumary ##
**Trello card**: https://trello.com/c/FJ6N5DPv/33-hacer-tests-del-signupviewmodel

Adding sign up view model tests.
Refactoring login view model tests when refactoring session service mock for tests to test view model and not mock logic.
Adding toggle visibility tests to login view model ones.
